### PR TITLE
Remove pull_request trigger from manifest-builder workflow

### DIFF
--- a/.github/workflows/manifest-builder.yml
+++ b/.github/workflows/manifest-builder.yml
@@ -3,8 +3,6 @@ name: Build Manifests
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
The manifest-builder workflow should only run on pushes to main, not on pull requests, since it creates commits and pushes to the target repo. Pull requests should use the pr-diff-comment workflow instead.