### PR TITLE
Set issuer to k8s.noa.re in idmouse.toml config

### DIFF
--- a/idmouse/idmouse.toml
+++ b/idmouse/idmouse.toml
@@ -4,7 +4,7 @@ signing_key_storage = "kubernetes_secret"
 
 [authentication]
 audience = "idmouse"
-issuer = "https://kubernetes.default.svc"
+issuer = "https://k8s.noa.re"
 
 [[mapping]]
 name = "idelephant"


### PR DESCRIPTION
Since we have updated the issuer url in the berries cluster, update the idmouse configuration as well