### PR TITLE
Update demo.resare.com to pull image from docker hub

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,7 +67,7 @@ external-secrets = [
 name = "demo.resare.com"
 namespace = "demo"
 args = ["-c", "/config/config.toml"]
-image = "packages.buildkite.com/nresare/oidc-client-demo/oidc-client-demo:0.1.0-f17a7e9f"
+image = "nresare/oidc-client-demo:latest"
 [website.config]
 "/config/config.toml" = "demo/config.toml"
 


### PR DESCRIPTION
Since we lost the buildkite packages setup, we need to use manually pushed images on docker hub