### PR TITLE
Bump reposnake to 0.2.1-56b70a18

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,7 +33,7 @@ extra-resources = "envoy-gateway/extra"
 name = "repo.noa.re"
 namespace = "reposnake"
 replicas = 2
-image = "repo.noa.re/reposnake:0.2.1-5b6295ce"
+image = "repo.noa.re/reposnake:0.2.1-56b70a18"
 args = ["-c", "/config/reposnake.toml"]
 config = { "/config/reposnake.toml" = "reposnake/reposnake.toml" }
 custom-token-audiences = ["idmouse", "sts.amazonaws.com"]


### PR DESCRIPTION
This change includes moving the python simple publish endpoint from /legacy to /