### PR TITLE
Revert "Update gateway-helm Docker tag to v1.8.0"

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -24,4 +24,4 @@ releases:
     version: 18.7.6
   - name: envoy-gateway
     chart: envoyproxy/gateway-helm
-    version: 1.8.0
+    version: 1.7.2


### PR DESCRIPTION
This reverts commit 7e48cba4a3f13a913306511ddd72c8df26e04da2.