### PR TITLE
Add default fields to backendRef in TLSRoute

### DIFF
--- a/teleport/extra/tlsroute-gateway-cluster.yaml
+++ b/teleport/extra/tlsroute-gateway-cluster.yaml
@@ -14,3 +14,6 @@ spec:
   - backendRefs:
     - name: teleport-cluster
       port: 443
+      group: ""
+      kind: Service
+      weight: 1


### PR DESCRIPTION
When removing the fields in this PR, Kubernetes will add them in again, making argo fail.