### PR TITLE
Implemented autodetection of jwks, update issuer url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -104,7 +104,7 @@ image = "repo.noa.re/jwksproxy:0.1.0-b89ffeed"
 name = "relcoord.noa.re"
 namespace = "relcoord"
 replicas = 2
-image = "repo.noa.re/relcoord:0.1.0-281c6fcd"
+image = "repo.noa.re/relcoord:0.1.0-f7caa804"
 config = { "/config/relcoord.toml" = "relcoord/relcoord.toml"}
 custom-token-audiences = ["idmouse"]
 

--- a/relcoord/relcoord.toml
+++ b/relcoord/relcoord.toml
@@ -9,3 +9,9 @@ database = "relcoord"
 [persistence.idmouse]
 url = "http://idmouse.idmouse.svc/token/relcoord"
 token_path = "/var/run/secrets/tokens/idmouse"
+
+[[role]]
+name = "manual"
+audience = "relcoord.noa.re"
+issuer = "https://k8s.noa.re"
+claims = { sub = "system:serviceaccount:default:default" }


### PR DESCRIPTION
The berries cluster is configured to issue tokens with issuer https://k8s.noa.re, so let's make sure we use that