### PR TITLE
Update relcoord to 0.1.0-2f878510, with buildkite fixes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -108,7 +108,7 @@ image = "repo.noa.re/jwksproxy:0.1.0-b89ffeed"
 name = "relcoord.noa.re"
 namespace = "relcoord"
 replicas = 2
-image = "repo.noa.re/relcoord:0.1.0-7c3c32b2"
+image = "repo.noa.re/relcoord:0.1.0-2f878510"
 config = { "/config/relcoord.toml" = "relcoord/relcoord.toml"}
 custom-token-audiences = ["idmouse", "idcat.noa.re"]
 


### PR DESCRIPTION
Previously we would not accept the buildkite tokens, as we limited the siganture algorithm to RS256