### PR TITLE
Configure Alloy static host scraping

### DIFF
--- a/alloy/alloy.cfg
+++ b/alloy/alloy.cfg
@@ -1,6 +1,20 @@
 prometheus.remote_write "mimir" {
   endpoint {
-    url = "http://mimir-nginx.mimir.svc/api/v1/push"
+    url = "http://mimir-distributor.mimir.svc:8080/api/v1/push"
   }
 }
 
+prometheus.scrape "static_hosts" {
+  targets = [
+    {
+      __address__ = "hallon:9100",
+      instance    = "host1",
+    },
+  ]
+
+  job_name        = "static-hosts"
+  scrape_interval = "60s"
+  metrics_path    = "/metrics"
+
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}


### PR DESCRIPTION
## Summary

- send Prometheus remote writes directly to the Mimir distributor
- scrape the hallon node exporter every 60 seconds
- forward static host metrics to Mimir

## Validation

- `git diff --check`