### PR TITLE
Set Alloy Mimir tenant header

### DIFF
--- a/alloy/alloy.cfg
+++ b/alloy/alloy.cfg
@@ -1,6 +1,9 @@
 prometheus.remote_write "mimir" {
   endpoint {
     url = "http://mimir-distributor.mimir.svc:8080/api/v1/push"
+    headers = {
+      "X-Scope-OrgID" = "anonymous",
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- set `X-Scope-OrgID` to `anonymous` on Alloy remote-write requests

## Validation

- `git diff --check`