### PR TITLE
Add Alloy scrape hosts

### DIFF
--- a/alloy/alloy.cfg
+++ b/alloy/alloy.cfg
@@ -13,6 +13,26 @@ prometheus.scrape "static_hosts" {
       __address__ = "hallon:9100",
       instance    = "host1",
     },
+    {
+      __address__ = "smultron:9100",
+      instance    = "smultron",
+    },
+    {
+      __address__ = "lingon:9100",
+      instance    = "lingon",
+    },
+    {
+      __address__ = "hjortron:9100",
+      instance    = "hjortron",
+    },
+    {
+      __address__ = "havtorn:9100",
+      instance    = "havtorn",
+    },
+    {
+      __address__ = "nadia:9100",
+      instance    = "nadia",
+    },
   ]
 
   job_name        = "static-hosts"


### PR DESCRIPTION
## Summary

- add smultron, lingon, hjortron, havtorn, and nadia as static Alloy scrape targets
- scrape node-exporter on port 9100 and label each target by hostname

## Validation

- `git diff --check`