### PR TITLE
Set Alloy Loki tenant header

### DIFF
--- a/alloy/log-forwarder.cfg
+++ b/alloy/log-forwarder.cfg
@@ -1,6 +1,9 @@
 loki.write "central" {
   endpoint {
     url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    headers = {
+      "X-Scope-OrgID" = "anonymous",
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- add `X-Scope-OrgID: anonymous` to the Alloy Loki write endpoint
- match the tenant header pattern used by the Mimir remote write config

## Validation

- `git diff --check`
- `helm template alloy-log-forwarder /Users/noa/.cache/manifest-builder/alloy-1.10.0/alloy --namespace alloy -f alloy/log-forwarder.yaml`