### PR TITLE
Configure trust-manager

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,10 @@ values = ["cert-manager/values.yaml"]
 extra-resources = "cert-manager/extra"
 
 [[helm]]
+namespace = "cert-manager"
+release = "trust-manager"
+
+[[helm]]
 namespace = "surrealdb"
 release = "surrealdb"
 values = ["surrealdb/values.yaml"]

--- a/releases.yaml
+++ b/releases.yaml
@@ -30,6 +30,9 @@ releases:
   - name: cert-manager
     chart: jetstack/cert-manager
     version: v1.21.0
+  - name: trust-manager
+    chart: jetstack/trust-manager
+    version: v0.24.0
   - name: surrealdb
     chart: surrealdb/surrealdb
     version: 0.5.0


### PR DESCRIPTION
## Summary

- add the Jetstack trust-manager Helm chart at v0.24.0
- deploy trust-manager in the cert-manager namespace

## Validation

- `git diff --check`
- parsed `config.toml` and `releases.yaml`
- resolved the pinned chart with Helm