### PR TITLE
Configure cluster-local certificate authority

### DIFF
--- a/cert-manager/extra/bundle-cluster-local-ca.yaml
+++ b/cert-manager/extra/bundle-cluster-local-ca.yaml
@@ -1,0 +1,15 @@
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: cluster-local-ca
+spec:
+  sources:
+    - secret:
+        name: cluster-local-ca
+        key: tls.crt
+  target:
+    configMap:
+      key: ca.crt
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: web

--- a/cert-manager/extra/certificate-cluster-local-ca.yaml
+++ b/cert-manager/extra/certificate-cluster-local-ca.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-local-ca
+  namespace: cert-manager
+spec:
+  commonName: berries cluster-local CA
+  duration: 87600h
+  isCA: true
+  issuerRef:
+    name: cluster-local-selfsigned
+    kind: ClusterIssuer
+    group: cert-manager.io
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Never
+  renewBefore: 8760h
+  secretName: cluster-local-ca
+  usages:
+    - cert sign
+    - crl sign
+    - digital signature

--- a/cert-manager/extra/clusterissuer-cluster-local-selfsigned.yaml
+++ b/cert-manager/extra/clusterissuer-cluster-local-selfsigned.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-local-selfsigned
+spec:
+  selfSigned: {}

--- a/cert-manager/extra/clusterissuer-cluster-local.yaml
+++ b/cert-manager/extra/clusterissuer-cluster-local.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-local
+spec:
+  ca:
+    secretName: cluster-local-ca


### PR DESCRIPTION
## Summary

- bootstrap a self-signed root certificate with cert-manager
- expose the root through a cluster-wide CA issuer
- distribute the CA certificate to the web namespace with trust-manager

## Validation

- parsed all added YAML with yq
- server-side dry-run against the live cluster CRDs
- generated berries manifests from the updated configuration