### PR TITLE
Expose Envoy HTTP/3 over UDP

### DIFF
--- a/envoy-gateway/extra/envoyproxy-custom-proxy-config.yaml
+++ b/envoy-gateway/extra/envoyproxy-custom-proxy-config.yaml
@@ -10,3 +10,18 @@ spec:
       envoyService:
         type: NodePort
         externalTrafficPolicy: Cluster
+        patch:
+          type: JSONMerge
+          value:
+            spec:
+              ports:
+                - name: https-443
+                  port: 443
+                  protocol: TCP
+                  targetPort: 10443
+                  nodePort: 31071
+                - name: https-443-udp
+                  port: 443
+                  protocol: UDP
+                  targetPort: 10443
+                  nodePort: 31071


### PR DESCRIPTION
## Summary

- patch the Envoy Gateway-managed NodePort Service to expose HTTPS over UDP
- retain TCP/443 and route both protocols to Envoy port 10443
- reuse NodePort 31071 for TCP and UDP

## Validation

- verified HTTP/3 connectivity locally
- `git diff --check`