### PR TITLE
Label Ceph dashboard service

### DIFF
--- a/rook-ceph/extra/cephcluster-rook-ceph.yaml
+++ b/rook-ceph/extra/cephcluster-rook-ceph.yaml
@@ -204,6 +204,8 @@ spec:
   #    mgr:
   #    cleanup:
   annotations:
+    dashboard:
+      teleport.dev/port: http-dashboard
   #   all:
   #   mon:
   #   mgr:
@@ -221,6 +223,8 @@ spec:
   # If no mgr annotations are set, prometheus scrape annotations will be set by default.
   #   mgr:
   labels:
+    dashboard:
+      noa.re/discover: enabled
   #   all:
   #   mon:
   #   osd:


### PR DESCRIPTION
## Summary

- label the Rook-managed Ceph dashboard service for discovery
- annotate the service with its Teleport HTTP port name

## Validation

- `git diff --check`