### PR TITLE
Set Rook-Ceph manager memory limits

### DIFF
--- a/rook-ceph/extra/cephcluster-rook-ceph.yaml
+++ b/rook-ceph/extra/cephcluster-rook-ceph.yaml
@@ -238,13 +238,11 @@ spec:
   #   monitoring:
   #   crashcollector:
   resources:
-  #The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
-  #   mgr:
-  #     limits:
-  #       memory: "1024Mi"
-  #     requests:
-  #       cpu: "500m"
-  #       memory: "1024Mi"
+    mgr:
+      requests:
+        memory: "512Mi"
+      limits:
+        memory: "1Gi"
   # The above example requests/limits can also be added to the other components
   #   mon:
   #   osd:


### PR DESCRIPTION
## Summary

- request 512Mi of memory for each Rook-Ceph manager pod
- cap manager memory at 1Gi, following the small-cluster sizing guidance

## Validation

- parsed the templated CephCluster YAML and verified the MGR resource values
- git diff --check