### PR TITLE
Scrape kube-state-metrics with Alloy

### DIFF
--- a/alloy/metrics.cfg
+++ b/alloy/metrics.cfg
@@ -7,6 +7,10 @@ prometheus.remote_write "mimir" {
   }
 }
 
+prometheus.operator.servicemonitors "services" {
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
 prometheus.scrape "static_hosts" {
   targets = [
     {

--- a/config.toml
+++ b/config.toml
@@ -84,6 +84,7 @@ values = ["argo/values.yaml"]
 [[helm]]
 namespace = "kube-state-metrics"
 release = "kube-state-metrics"
+extra-resources = "kube-state-metrics/extra"
 
 [[website]]
 name = "zq.lu"

--- a/kube-state-metrics/extra/servicemonitor-kube-state-metrics.yaml
+++ b/kube-state-metrics/extra/servicemonitor-kube-state-metrics.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-state-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: kube-state-metrics
+      app.kubernetes.io/name: kube-state-metrics
+  endpoints:
+    - port: http


### PR DESCRIPTION
## Summary

- add a ServiceMonitor targeting the kube-state-metrics HTTP endpoint
- deploy it through the kube-state-metrics extra resources directory
- configure Alloy to discover ServiceMonitors and forward metrics to Mimir

## Validation

- `git diff --check`
- parsed `config.toml` with Python `tomllib`
- parsed and asserted the ServiceMonitor selector and endpoint fields