### PR TITLE
Scrape kubelet resource metrics

### DIFF
--- a/alloy/metrics-extra/clusterrole-kubelet-proxy.yaml
+++ b/alloy/metrics-extra/clusterrole-kubelet-proxy.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alloy-kubelet-proxy
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+    verbs:
+      - get

--- a/alloy/metrics-extra/clusterrolebinding-kubelet-proxy.yaml
+++ b/alloy/metrics-extra/clusterrolebinding-kubelet-proxy.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alloy-kubelet-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alloy-kubelet-proxy
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: alloy

--- a/alloy/metrics.cfg
+++ b/alloy/metrics.cfg
@@ -11,6 +11,41 @@ prometheus.operator.servicemonitors "services" {
   forward_to = [prometheus.remote_write.mimir.receiver]
 }
 
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+
+discovery.relabel "kubelet_resource_metrics" {
+  targets = discovery.kubernetes.nodes.targets
+
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc:443"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    target_label  = "__metrics_path__"
+    replacement   = "/api/v1/nodes/$1/proxy/metrics/resource"
+  }
+}
+
+prometheus.scrape "kubelet_resource_metrics" {
+  targets = discovery.relabel.kubelet_resource_metrics.output
+
+  job_name          = "kubelet-resource-metrics"
+  scheme            = "https"
+  scrape_interval   = "15s"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  tls_config {
+    ca_file     = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    server_name = "kubernetes.default.svc"
+  }
+
+  forward_to = [prometheus.remote_write.mimir.receiver]
+}
+
 prometheus.scrape "static_hosts" {
   targets = [
     {

--- a/config.toml
+++ b/config.toml
@@ -52,6 +52,7 @@ namespace = "alloy"
 release = "alloy"
 values = ["alloy/metrics.yaml"]
 config = {"metrics.cfg" = "alloy/metrics.cfg"}
+extra-resources = "alloy/metrics-extra"
 
 [[helm]]
 namespace = "alloy"


### PR DESCRIPTION
## Summary

- discover Kubernetes nodes from the metrics Alloy instance
- scrape each kubelet `/metrics/resource` endpoint through the Kubernetes API proxy every 15 seconds
- remote write kubelet resource-usage metrics to Mimir
- grant the Alloy service account `get` access to `nodes/proxy`

## Validation

- `git diff --check`
- parsed `config.toml` with Python `tomllib`
- parsed both RBAC manifests as YAML
- rendered Alloy chart 1.11.0 and verified the `alloy` service account and existing Node discovery permissions