### PR TITLE
Set Ceph OSD memory resources

### DIFF
--- a/rook-ceph/extra/cephcluster-rook-ceph.yaml
+++ b/rook-ceph/extra/cephcluster-rook-ceph.yaml
@@ -243,6 +243,11 @@ spec:
         memory: "512Mi"
       limits:
         memory: "1Gi"
+    osd:
+      requests:
+        memory: "800Mi"
+      limits:
+        memory: "1Gi"
   # The above example requests/limits can also be added to the other components
   #   mon:
   #   osd:


### PR DESCRIPTION
## Summary

- request 800Mi of memory for Ceph OSD pods
- limit Ceph OSD pods to 1Gi of memory

## Validation

- `yq eval`
- `git diff --check`