### PR TITLE
Raise Ceph OSD memory resources

### DIFF
--- a/rook-ceph/extra/cephcluster-rook-ceph.yaml
+++ b/rook-ceph/extra/cephcluster-rook-ceph.yaml
@@ -245,9 +245,9 @@ spec:
         memory: "1Gi"
     osd:
       requests:
-        memory: "800Mi"
-      limits:
         memory: "1Gi"
+      limits:
+        memory: "1.5Gi"
   # The above example requests/limits can also be added to the other components
   #   mon:
   #   osd:


### PR DESCRIPTION
## Summary

- raise the Ceph OSD memory request from 800Mi to 1Gi
- raise the Ceph OSD memory limit from 1Gi to 1.5Gi
- keep Ceph 20.2.2's derived OSD memory target above its 896Mi minimum

With a 1.5Gi limit, Ceph derives a 1.2Gi cgroup-based target. The 1Gi request then becomes the effective target while the remaining 512Mi provides cgroup headroom.

## Validation

- parsed the CephCluster YAML with `yq eval`
- validated both memory quantities with `kubectl create quota --dry-run=client`
- `git diff --check`