### PR TITLE
Collect Kubernetes events with Alloy

### DIFF
--- a/alloy/metrics.cfg
+++ b/alloy/metrics.cfg
@@ -7,6 +7,21 @@ prometheus.remote_write "mimir" {
   }
 }
 
+loki.write "central" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    headers = {
+      "X-Scope-OrgID" = "anonymous",
+    }
+  }
+}
+
+loki.source.kubernetes_events "cluster_events" {
+  job_name   = "kubernetes-events"
+  log_format = "json"
+  forward_to = [loki.write.central.receiver]
+}
+
 prometheus.operator.servicemonitors "services" {
   forward_to = [prometheus.remote_write.mimir.receiver]
 }


### PR DESCRIPTION
## Summary

- collect cluster-wide Kubernetes events with the deployment-based Alloy instance
- encode events as JSON and forward them to the existing Loki tenant

## Validation

- `git diff --check`
- rendered Grafana Alloy chart 1.11.0 and verified the Deployment service account has `get`, `list`, and `watch` access to events