### PR TITLE
Set Ceph monitor memory resources

### DIFF
--- a/rook-ceph/extra/cephcluster-rook-ceph.yaml
+++ b/rook-ceph/extra/cephcluster-rook-ceph.yaml
@@ -238,6 +238,11 @@ spec:
   #   monitoring:
   #   crashcollector:
   resources:
+    mon:
+      requests:
+        memory: "768Mi"
+      limits:
+        memory: "1536Mi"
     mgr:
       requests:
         memory: "512Mi"


### PR DESCRIPTION
## Summary

- request 768Mi of memory for each Ceph monitor
- cap monitor memory at 1536Mi to retain recovery headroom while limiting node pressure

## Validation

- `yq eval '.' rook-ceph/extra/cephcluster-rook-ceph.yaml`
- `git diff --check`