### PR TITLE
Fix Alloy host journal collection

### DIFF
--- a/alloy/log-forwarder.cfg
+++ b/alloy/log-forwarder.cfg
@@ -46,10 +46,21 @@ loki.source.kubernetes "pod_logs" {
   forward_to = [loki.write.central.receiver]
 }
 
+loki.relabel "journal" {
+  forward_to = []
+
+  rule {
+    source_labels = ["__journal__hostname"]
+    target_label  = "node"
+  }
+}
+
 loki.source.journal "kubelite" {
-  forward_to = [loki.write.central.receiver]
-  matches    = "_SYSTEMD_UNIT=snap.microk8s.daemon-kubelite.service"
-  labels     = {
+  forward_to    = [loki.write.central.receiver]
+  matches       = "_SYSTEMD_UNIT=snap.microk8s.daemon-kubelite.service"
+  path          = "/var/log/journal"
+  relabel_rules = loki.relabel.journal.rules
+  labels        = {
     service = "kubelite",
     unit    = "snap.microk8s.daemon-kubelite.service",
   }

--- a/alloy/log-forwarder.cfg
+++ b/alloy/log-forwarder.cfg
@@ -61,7 +61,7 @@ loki.source.journal "kubelite" {
   path          = "/var/log/journal"
   relabel_rules = loki.relabel.journal.rules
   labels        = {
-    service = "kubelite",
-    unit    = "snap.microk8s.daemon-kubelite.service",
+    service_name = "kubelite",
+    unit         = "snap.microk8s.daemon-kubelite.service",
   }
 }

--- a/alloy/log-forwarder.yaml
+++ b/alloy/log-forwarder.yaml
@@ -10,6 +10,9 @@ alloy:
       - name: run-log-journal
         mountPath: /run/log/journal
         readOnly: true
+      - name: machine-id
+        mountPath: /etc/machine-id
+        readOnly: true
 
 controller:
   type: daemonset
@@ -19,4 +22,7 @@ controller:
         hostPath:
           path: /run/log/journal
           type: DirectoryOrCreate
-
+      - name: machine-id
+        hostPath:
+          path: /etc/machine-id
+          type: File


### PR DESCRIPTION
## Summary

- mount each node's `/etc/machine-id` into the Alloy log-forwarder
- read the persistent host journal explicitly from `/var/log/journal`
- retain the journal hostname as a `node` label to keep host streams distinct
- label kubelite streams with `service_name="kubelite"` for consistency with existing Loki queries

## Validation

- `git diff --check`
- validated `alloy/log-forwarder.cfg` with Alloy v1.18.0
- rendered `alloy/log-forwarder.yaml` with Alloy Helm chart 1.11.0