### PR TITLE
Truncate oversized Alloy log entries

### DIFF
--- a/alloy/log-forwarder.cfg
+++ b/alloy/log-forwarder.cfg
@@ -7,6 +7,18 @@ loki.write "central" {
   }
 }
 
+loki.process "truncate_oversized" {
+  forward_to = [loki.write.central.receiver]
+
+  stage.truncate {
+    rule {
+      limit       = "250KiB"
+      source_type = "line"
+      suffix      = "... [truncated by Alloy]"
+    }
+  }
+}
+
 discovery.kubernetes "pods" {
   role = "pod"
 }
@@ -43,7 +55,7 @@ discovery.relabel "pod_logs" {
 
 loki.source.kubernetes "pod_logs" {
   targets    = discovery.relabel.pod_logs.output
-  forward_to = [loki.write.central.receiver]
+  forward_to = [loki.process.truncate_oversized.receiver]
 }
 
 loki.relabel "journal" {
@@ -56,7 +68,7 @@ loki.relabel "journal" {
 }
 
 loki.source.journal "kubelite" {
-  forward_to    = [loki.write.central.receiver]
+  forward_to    = [loki.process.truncate_oversized.receiver]
   matches       = "_SYSTEMD_UNIT=snap.microk8s.daemon-kubelite.service"
   path          = "/var/log/journal"
   relabel_rules = loki.relabel.journal.rules


### PR DESCRIPTION
## Summary

- route pod and host journal logs through a shared Alloy processing stage
- truncate log lines at 250 KiB, safely below Loki's 256 KiB entry limit
- append a visible marker to truncated lines

This prevents a single oversized entry, such as the observed Ceph manager messages, from causing Loki to reject a complete write batch. Alloy exposes truncations through `loki_process_truncated_fields_total`.

## Validation

- `git diff --check`
- validated `alloy/log-forwarder.cfg` with the live Alloy v1.18.0 binary