### PR TITLE
Name the website block, and take local copies of helm and simple

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ committed to [berries-manifests](https://github.com/nresare/berries-manifests).
 
 The `[[website]]` config block is implemented locally in
 [`plugins/website.py`](./plugins/website.py), with its Mustache templates and
-tests alongside it. Manifest-builder discovers the handler from the top-level
+tests alongside it. Manifest-builder discovers the block from the top-level
 `plugins/` directory when this configuration is loaded.
 
 ### Hugo website backend TLS

--- a/plugins/helm.py
+++ b/plugins/helm.py
@@ -1,0 +1,596 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: The manifest-builder contributors
+"""Helm chart config block."""
+
+import logging
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+import pystache
+from manifest_builder.blocks import ConfigBlock, GenerationContext
+from manifest_builder.config import (
+    TemplateValue,
+    parse_variables,
+    validate_known_fields,
+)
+from manifest_builder.helm import ChartCacheStats, pull_chart, run_helm_template
+from manifest_builder.helmfile import Helmfile
+from manifest_builder.k8s import (
+    CLUSTER_SCOPED_KINDS,
+    config_checksum,
+    inject_custom_token_projection,
+)
+from manifest_builder.output import (
+    dump_all_yaml,
+    load_all_yaml,
+    write_documents,
+    write_manifests,
+)
+from pystache.common import MissingTags
+
+logger = logging.getLogger(__name__)
+
+# Concurrent renders share the chart cache, whose download path is not atomic.
+_HELM_PULL_LOCK = Lock()
+
+
+@dataclass
+class ChartConfig:
+    """Configuration for a single Helm chart."""
+
+    name: str
+    namespace: str
+    chart: str | None  # None when using a helmfile release reference
+    repo: str | None
+    version: str | None
+    values: list[Path]
+    release: str | None  # helmfile release name; None for direct chart entries
+    variables: dict[str, TemplateValue] = field(default_factory=dict)
+    extra_resources: Path | None = (
+        None  # directory with additional YAML resources to include
+    )
+    init: Path | None = None  # optional shell script to inject as initContainer
+    config: dict[str, Path] | None = None  # ConfigMap key -> resolved local path
+    name_override: str | None = None  # optional release name passed to helm template
+    custom_token_audiences: list[str] | None = None
+
+
+def validate_chart_config(config: ChartConfig, repo_root: Path) -> None:
+    """Validate a Helm chart configuration."""
+    for values_path in config.values:
+        if not values_path.exists():
+            raise ValueError(
+                f"Values file not found for chart '{config.name}': {values_path}"
+            )
+
+    for config_key, local_path in (config.config or {}).items():
+        if not local_path.exists():
+            raise ValueError(
+                f"Config file not found for chart '{config.name}': {local_path} "
+                f"(mapped from {config_key})"
+            )
+
+    if config.extra_resources is not None:
+        if not config.extra_resources.exists():
+            raise ValueError(
+                f"Extra resources directory not found for '{config.name}': {config.extra_resources}"
+            )
+        if not config.extra_resources.is_dir():
+            raise ValueError(
+                f"Extra resources path is not a directory for '{config.name}': {config.extra_resources}"
+            )
+
+    if config.chart is not None and (
+        config.chart.startswith("./") or config.chart.startswith("/")
+    ):
+        chart_path = repo_root / config.chart
+        if not chart_path.exists():
+            raise ValueError(
+                f"Local chart path not found for '{config.name}': {config.chart}"
+            )
+
+    if config.init is not None and not config.init.exists():
+        raise ValueError(f"init script not found for '{config.name}': {config.init}")
+
+
+class HelmBlock(ConfigBlock[ChartConfig]):
+    """Generate manifests for Helm chart configs."""
+
+    # Each chart renders into its own temporary directory, so renders may
+    # overlap. Chart cache downloads are serialized by _HELM_PULL_LOCK.
+    parallel_safe = True
+
+    def __init__(self, configs: Sequence[ChartConfig] | None = None) -> None:
+        self.configs = list(configs or [])
+
+    def top_level_config_name(self) -> str:
+        return "helm"
+
+    def load_config(
+        self,
+        data: object,
+        source_file: Path,
+        root_config: dict[str, Any],
+        default_namespace: str | None = None,
+        default_image: str | None = None,
+    ) -> None:
+        del default_image
+        if not isinstance(data, list):
+            raise ValueError(f"'helm' must be a list of tables in {source_file}")
+
+        variables = parse_variables(root_config.get("variables"), source_file)
+        for index, item in enumerate(data):
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"Each [[helm]] entry must be a table in {source_file}"
+                )
+            self.configs.append(
+                _parse_chart_config(
+                    item, source_file, variables, index, default_namespace
+                )
+            )
+
+    def iter_configs(self) -> Sequence[ChartConfig]:
+        return self.configs
+
+    def resolve(self, helmfile: Helmfile | None) -> None:
+        if not any(config.release for config in self.configs):
+            return
+
+        if helmfile is None:
+            names = [config.name for config in self.configs if config.release]
+            raise ValueError(
+                f"Charts {names} reference helmfile releases but no releases.yaml was found"
+            )
+
+        release_data = _get_helmfile_data(helmfile)
+        repo_by_name = release_data[0]
+        release_by_name = release_data[1]
+
+        resolved: list[ChartConfig] = []
+        for config in self.configs:
+            if config.release is None:
+                resolved.append(config)
+                continue
+
+            release_name = config.release
+            if release_name not in release_by_name:
+                raise ValueError(f"Release '{release_name}' not found in releases.yaml")
+
+            hf_release = release_by_name[release_name]
+
+            parts = hf_release.chart.split("/", 1)
+            if len(parts) != 2:
+                raise ValueError(
+                    f"helmfile release '{release_name}' chart '{hf_release.chart}' "
+                    "must be in 'reponame/chartname' format"
+                )
+            repo_name, chart_name = parts
+
+            if repo_name not in repo_by_name:
+                raise ValueError(
+                    f"Repository '{repo_name}' referenced by release '{release_name}' "
+                    "not found in releases.yaml repositories"
+                )
+
+            repo_url = repo_by_name[repo_name]
+
+            if repo_url.startswith("oci://"):
+                base_url = repo_url.rstrip("/")
+                resolved_chart = f"{base_url}/{chart_name}"
+                resolved_repo = None
+            else:
+                resolved_chart = chart_name
+                resolved_repo = repo_url
+
+            resolved.append(
+                ChartConfig(
+                    name=config.name,
+                    namespace=config.namespace,
+                    chart=resolved_chart,
+                    repo=resolved_repo,
+                    version=hf_release.version,
+                    values=config.values,
+                    variables=config.variables,
+                    release=config.release,
+                    extra_resources=config.extra_resources,
+                    init=config.init,
+                    config=config.config,
+                    name_override=config.name_override,
+                    custom_token_audiences=config.custom_token_audiences,
+                )
+            )
+
+        self.configs = resolved
+
+    def validate(self, config: ChartConfig, repo_root: Path) -> None:
+        validate_chart_config(config, repo_root)
+
+    def generate(
+        self,
+        config: ChartConfig,
+        context: GenerationContext,
+    ) -> set[Path]:
+        return _generate_helm_manifests(
+            config,
+            context.output_dir,
+            context.charts_dir,
+            context.verbose,
+            images=context.images,
+            cache_stats=context.cache_stats,
+        )
+
+
+def _parse_chart_config(
+    data: dict,
+    source_file: Path,
+    variables: dict[str, TemplateValue],
+    table_index: int = 0,
+    default_namespace: str | None = None,
+) -> ChartConfig:
+    """Parse a single Helm chart configuration from TOML data."""
+    validate_known_fields(
+        "[[helm]]",
+        data,
+        {
+            "name",
+            "namespace",
+            "chart",
+            "release",
+            "repo",
+            "version",
+            "values",
+            "config",
+            "extra-resources",
+            "init",
+            "name-override",
+            "custom-token-audience",
+            "custom-token-audiences",
+        },
+        source_file,
+        table_index,
+    )
+
+    has_release = "release" in data
+    has_chart = "chart" in data
+
+    if has_release and has_chart:
+        raise ValueError(f"Cannot specify both 'release' and 'chart' in {source_file}")
+    if not has_release and not has_chart:
+        raise ValueError(f"Must specify either 'release' or 'chart' in {source_file}")
+    if "namespace" not in data and default_namespace is None:
+        raise ValueError(f"Missing required field 'namespace' in {source_file}")
+
+    config_dir = source_file.parent
+    namespace = data.get("namespace", default_namespace)
+    raw_values = data.get("values", [])
+    if isinstance(raw_values, str):
+        raw_values = [raw_values]
+    values = [config_dir / v for v in raw_values]
+
+    extra_resources = None
+    if "extra-resources" in data:
+        extra_resources = config_dir / data["extra-resources"]
+
+    init = None
+    if "init" in data:
+        init = config_dir / data["init"]
+
+    config_files = _parse_chart_config_files(data.get("config"), source_file)
+    custom_token_audiences = _parse_custom_token_audiences(data, source_file)
+
+    if has_release:
+        return ChartConfig(
+            name=data["release"],
+            namespace=namespace,
+            chart=None,
+            repo=None,
+            version=None,
+            values=values,
+            variables=variables.copy(),
+            release=data["release"],
+            extra_resources=extra_resources,
+            init=init,
+            config=config_files,
+            name_override=data.get("name-override"),
+            custom_token_audiences=custom_token_audiences,
+        )
+
+    if "name" not in data:
+        raise ValueError(f"Missing required field 'name' in {source_file}")
+    return ChartConfig(
+        name=data["name"],
+        namespace=namespace,
+        chart=data["chart"],
+        repo=data.get("repo"),
+        version=data.get("version"),
+        values=values,
+        variables=variables.copy(),
+        release=None,
+        extra_resources=extra_resources,
+        init=init,
+        config=config_files,
+        name_override=data.get("name-override"),
+        custom_token_audiences=custom_token_audiences,
+    )
+
+
+def _parse_custom_token_audiences(data: dict, source_file: Path) -> list[str] | None:
+    """Normalize singular and plural custom token audience fields."""
+    custom_token_audience = data.get("custom-token-audience")
+    custom_token_audiences = data.get("custom-token-audiences")
+
+    if custom_token_audience is not None and custom_token_audiences is not None:
+        raise ValueError(
+            f"Cannot specify both 'custom-token-audience' and "
+            f"'custom-token-audiences' in {source_file}"
+        )
+
+    if custom_token_audience is not None:
+        if not isinstance(custom_token_audience, str):
+            raise ValueError(
+                f"'custom-token-audience' must be a string in {source_file}"
+            )
+        return [custom_token_audience]
+
+    if custom_token_audiences is not None and (
+        not isinstance(custom_token_audiences, list)
+        or not all(isinstance(audience, str) for audience in custom_token_audiences)
+    ):
+        raise ValueError(
+            f"'custom-token-audiences' must be a list of strings in {source_file}"
+        )
+
+    return custom_token_audiences
+
+
+def _parse_chart_config_files(
+    data: object, source_file: Path
+) -> dict[str, Path] | None:
+    """Parse Helm ConfigMap file mappings as config-key -> local file path."""
+    if data is None:
+        return None
+
+    if not isinstance(data, dict):
+        raise ValueError(f"'helm.config' must be a table in {source_file}")
+
+    config_dir = source_file.parent
+    config_files: dict[str, Path] = {}
+    for config_key, local_path in data.items():
+        if not isinstance(config_key, str) or not isinstance(local_path, str):
+            raise ValueError(
+                f"'helm.config' entries must map strings to strings in {source_file}"
+            )
+        config_files[config_key] = config_dir / local_path
+
+    return config_files
+
+
+def _get_helmfile_data(helmfile: Helmfile) -> tuple[dict[str, str], dict[str, Any]]:
+    repositories = helmfile.repositories
+    releases = helmfile.releases
+    repo_by_name = {
+        repo.name: (f"oci://{repo.url}" if repo.oci else repo.url)
+        for repo in repositories
+    }
+    release_by_name = {release.name: release for release in releases}
+    return repo_by_name, release_by_name
+
+
+def _generate_helm_manifests(
+    config: ChartConfig,
+    output_dir: Path,
+    charts_dir: Path,
+    verbose: bool = False,
+    images: dict[str, str] | None = None,
+    cache_stats: ChartCacheStats | None = None,
+) -> set[Path]:
+    """Generate manifests from a Helm chart.
+
+    Args:
+        config: Helm chart configuration
+        output_dir: Directory to write generated manifests
+        charts_dir: Directory for caching pulled charts
+        verbose: If True, log detailed output
+        cache_stats: Optional chart cache hit/miss counter to update
+
+    Returns:
+        Set of paths written
+    """
+    logger.debug(f"Chart: {config.chart}")
+    if config.repo:
+        logger.debug(f"Repo: {config.repo}")
+    if config.version:
+        logger.debug(f"Version: {config.version}")
+    if config.values:
+        logger.debug(f"Values: {', '.join(str(v) for v in config.values)}")
+
+    if config.chart is None:
+        raise ValueError(
+            f"Chart '{config.name}' has no resolved chart reference; "
+            "ensure resolve_configs() was called before generate_manifests()"
+        )
+
+    # Pull the chart from the repo if configured (traditional or OCI)
+    if config.repo or (config.chart and config.chart.startswith("oci://")):
+        version_suffix = f"-{config.version}" if config.version else ""
+
+        # Create a filesystem-safe directory name for the cache
+        if config.chart.startswith("oci://"):
+            chart_slug = config.chart.replace("oci://", "").replace("/", "_")
+        else:
+            chart_slug = config.chart
+
+        pull_dest = charts_dir / f"{chart_slug}{version_suffix}"
+
+        with _HELM_PULL_LOCK:
+            chart_path = str(
+                pull_chart(
+                    chart=config.chart,
+                    dest=pull_dest,
+                    repo=config.repo,
+                    version=config.version,
+                    cache_stats=cache_stats,
+                )
+            )
+    else:
+        chart_path = config.chart
+
+    values_context: dict[str, TemplateValue | str] = {
+        **(images or {}),
+        **config.variables,
+    }
+    helm_release_name = config.name_override or config.name
+    with tempfile.TemporaryDirectory(prefix="manifest-builder-values-") as temp_dir:
+        values_paths = _render_values_files(
+            config.values, Path(temp_dir), values_context
+        )
+        manifest_content = run_helm_template(
+            release_name=helm_release_name,
+            chart=chart_path,
+            namespace=config.namespace,
+            values_files=values_paths,
+        )
+
+    if config.custom_token_audiences:
+        docs = load_all_yaml(manifest_content)
+        deployments = [doc for doc in docs if doc.get("kind") == "Deployment"]
+        if len(deployments) != 1:
+            raise ValueError(
+                f"Custom token audience injection for Helm chart '{config.name}' "
+                f"requires exactly one Deployment, found {len(deployments)}"
+            )
+        inject_custom_token_projection(deployments[0], config.custom_token_audiences)
+        manifest_content = dump_all_yaml(docs)
+
+    # Inject init container if configured
+    if config.init:
+        docs = load_all_yaml(manifest_content)
+        deployments = [d for d in docs if d.get("kind") == "Deployment"]
+        if len(deployments) != 1:
+            raise ValueError(
+                f"init requires exactly one Deployment in chart '{config.name}', "
+                f"found {len(deployments)}"
+            )
+        alpine_image = (images or {}).get("alpine_image")
+        if not alpine_image:
+            raise ValueError(
+                f"init requires 'alpine_image' to be defined in images.toml "
+                f"for '{config.name}'"
+            )
+        script = config.init.read_text()
+        deployment = deployments[0]
+        pod_spec = (
+            deployment.setdefault("spec", {})
+            .setdefault("template", {})
+            .setdefault("spec", {})
+        )
+        # Collect unique volumeMounts from all containers
+        seen = set()
+        volume_mounts = []
+        for container in pod_spec.get("containers", []):
+            for vm in container.get("volumeMounts", []):
+                key = (vm.get("name"), vm.get("mountPath"))
+                if key not in seen:
+                    seen.add(key)
+                    volume_mounts.append(vm)
+        init_container: dict = {
+            "name": config.init.stem,
+            "image": alpine_image,
+            "command": ["/bin/sh", "-c", script],
+        }
+        if volume_mounts:
+            init_container["volumeMounts"] = volume_mounts
+        pod_spec["initContainers"] = [init_container]
+        # Re-serialize; write_manifests will re-parse
+        manifest_content = dump_all_yaml(docs)
+
+    configmap = None
+    if config.config:
+        configmap = _make_helm_configmap(
+            helm_release_name, config.namespace, config.config
+        )
+        checksum = config_checksum([configmap])
+        docs = load_all_yaml(manifest_content)
+        for doc in docs:
+            if doc.get("kind") in {"Deployment", "StatefulSet"}:
+                doc.setdefault("spec", {}).setdefault("template", {}).setdefault(
+                    "metadata", {}
+                ).setdefault("annotations", {})["checksum/config"] = checksum
+
+        manifest_content = dump_all_yaml(docs)
+
+    paths = write_manifests(manifest_content, output_dir, config.namespace, config.name)
+
+    if configmap:
+        paths.update(
+            write_documents([configmap], output_dir, config.namespace, config.name)
+        )
+
+    # Handle extra resources if configured
+    if config.extra_resources:
+        renderer = pystache.Renderer(missing_tags=MissingTags.strict)
+        extra_docs: list[dict] = []
+        for yaml_file in sorted(config.extra_resources.glob("*.yaml")):
+            rendered = renderer.render(yaml_file.read_text(), values_context)
+            for doc in load_all_yaml(rendered):
+                # Add namespace to namespaced resources without one
+                kind = doc.get("kind")
+                if (
+                    kind
+                    and kind not in CLUSTER_SCOPED_KINDS
+                    and "namespace" not in doc.get("metadata", {})
+                ):
+                    doc.setdefault("metadata", {})["namespace"] = config.namespace
+                extra_docs.append(doc)
+        if extra_docs:
+            extra_paths = write_documents(
+                extra_docs, output_dir, config.namespace, config.name
+            )
+            paths.update(extra_paths)
+            logger.debug(f"Copied {len(extra_docs)} extra resources")
+
+    return paths
+
+
+def _make_helm_configmap(
+    name: str,
+    namespace: str,
+    config_files: dict[str, Path],
+) -> dict:
+    """Build a Helm companion ConfigMap from config-key -> local file mappings."""
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": f"{name}-config",
+            "namespace": namespace,
+        },
+        "data": {
+            config_key: local_path.read_text()
+            for config_key, local_path in sorted(config_files.items())
+        },
+    }
+
+
+def _render_values_files(
+    values_paths: list[Path],
+    temp_dir: Path,
+    context: dict[str, TemplateValue | str],
+) -> list[Path]:
+    """Render values files as Mustache templates into temporary files."""
+    if not values_paths:
+        return []
+
+    renderer = pystache.Renderer(missing_tags=MissingTags.strict)
+    rendered_paths: list[Path] = []
+    for index, values_path in enumerate(values_paths):
+        rendered_path = temp_dir / f"{index:02d}-{values_path.name}"
+        rendered_path.write_text(renderer.render(values_path.read_text(), context))
+        rendered_paths.append(rendered_path)
+
+    return rendered_paths

--- a/plugins/pyproject.toml
+++ b/plugins/pyproject.toml
@@ -18,7 +18,7 @@ pythonpath = ["."]
 testpaths = ["tests"]
 
 [tool.ruff.lint.per-file-ignores]
-# Config handlers consistently report malformed user configuration as ValueError.
+# Config blocks consistently report malformed user configuration as ValueError.
 "website.py" = ["TRY004"]
 
 [[tool.uv.index]]

--- a/plugins/pyproject.toml
+++ b/plugins/pyproject.toml
@@ -19,6 +19,8 @@ testpaths = ["tests"]
 
 [tool.ruff.lint.per-file-ignores]
 # Config blocks consistently report malformed user configuration as ValueError.
+"helm.py" = ["TRY004"]
+"simple.py" = ["TRY004"]
 "website.py" = ["TRY004"]
 
 [[tool.uv.index]]

--- a/plugins/simple.py
+++ b/plugins/simple.py
@@ -1,0 +1,571 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: The manifest-builder contributors
+"""Simple manifest generation from plugin-owned Mustache templates."""
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from manifest_builder.blocks import ConfigBlock, GenerationContext
+from manifest_builder.config import (
+    DEFAULT_REPLICA_COUNT,
+    TemplateValue,
+    parse_variables,
+    validate_known_fields,
+)
+from manifest_builder.k8s import (
+    CLUSTER_SCOPED_KINDS,
+    config_checksum,
+    configmap_suffix_from_mount_path,
+    inject_custom_token_projection,
+    make_configmaps,
+    make_k8s_name,
+    secret_name_from_mount_path,
+)
+from manifest_builder.output import write_documents
+
+
+@dataclass
+class SimpleConfig:
+    """Configuration for a simple deployment built from plugin-owned YAML templates."""
+
+    name: str
+    namespace: str
+    image: str
+    args: list[str] | None = None
+    iam_role: str | None = None
+    k8s_role: str | None = None
+    service_account_annotations: dict[str, str] | None = (
+        None  # extra annotations for the managed ServiceAccount
+    )
+    config: dict[str, Path] | None = None  # container path -> resolved local path
+    external_secrets: list[str] | None = (
+        None  # mount paths for external secrets (e.g., ["/email-password"])
+    )
+    custom_token_audiences: list[str] | None = None
+    variables: dict[str, TemplateValue] = field(default_factory=dict)
+    extra_resources: Path | None = (
+        None  # directory with additional YAML resources to include
+    )
+    replicas: int = DEFAULT_REPLICA_COUNT  # number of deployment replicas
+    arch: str | None = None  # node architecture (sets kubernetes.io/arch nodeSelector)
+    random_secrets: list[str] | None = (
+        None  # secret key names for a RandomSecret mounted at /random-secrets
+    )
+
+
+def validate_simple_config(config: SimpleConfig) -> None:
+    """Validate a simple app configuration."""
+    for container_path, local_path in (config.config or {}).items():
+        if not local_path.exists():
+            raise ValueError(
+                f"Config file not found for '{config.name}': {local_path} "
+                f"(mapped from {container_path})"
+            )
+
+    if config.extra_resources is not None:
+        if not config.extra_resources.exists():
+            raise ValueError(
+                f"Extra resources directory not found for '{config.name}': {config.extra_resources}"
+            )
+        if not config.extra_resources.is_dir():
+            raise ValueError(
+                f"Extra resources path is not a directory for '{config.name}': {config.extra_resources}"
+            )
+
+
+# Annotation the ServiceAccount template emits for 'iam-role' (EKS IRSA).
+IAM_ROLE_ANNOTATION = "eks.amazonaws.com/role-arn"
+
+
+class SimpleBlock(ConfigBlock[SimpleConfig]):
+    """Generate manifests for simple configs."""
+
+    def __init__(self, configs: Sequence[SimpleConfig] | None = None) -> None:
+        self.configs = list(configs or [])
+
+    def top_level_config_name(self) -> str:
+        return "simple"
+
+    def load_config(
+        self,
+        data: object,
+        source_file: Path,
+        root_config: dict[str, Any],
+        default_namespace: str | None = None,
+        default_image: str | None = None,
+    ) -> None:
+        if not isinstance(data, list):
+            raise ValueError(f"'simple' must be a list of tables in {source_file}")
+
+        variables = parse_variables(root_config.get("variables"), source_file)
+        for index, item in enumerate(data):
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"Each [[simple]] entry must be a table in {source_file}"
+                )
+            self.configs.append(
+                _parse_simple_config(
+                    item,
+                    source_file,
+                    variables,
+                    index,
+                    default_namespace,
+                    default_image,
+                )
+            )
+
+    def iter_configs(self) -> list[SimpleConfig]:
+        return self.configs
+
+    def validate(self, config: SimpleConfig, repo_root: Path) -> None:
+        validate_simple_config(config)
+
+    def generate(
+        self,
+        config: SimpleConfig,
+        context: GenerationContext,
+    ) -> set[Path]:
+        return generate_simple(
+            config,
+            context.output_dir,
+            images=context.images,
+        )
+
+
+def _parse_config_files(data: object, source_file: Path) -> dict[str, Path] | None:
+    """Parse config file mappings from inline or array-of-table TOML syntax."""
+    if data is None:
+        return None
+
+    config_data: dict[str, str] = {}
+    if isinstance(data, list):
+        for item in data:
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"Each [[simple.config]] entry must be a table in {source_file}"
+                )
+            config_data.update(_parse_config_file_table(item, source_file))
+    elif isinstance(data, dict):
+        config_data = _parse_config_file_table(data, source_file)
+    else:
+        raise ValueError(f"'simple.config' must be a table in {source_file}")
+
+    config_dir = source_file.parent
+    return {
+        container_path: config_dir / local_path
+        for container_path, local_path in config_data.items()
+    }
+
+
+def _parse_config_file_table(data: dict, source_file: Path) -> dict[str, str]:
+    config_data: dict[str, str] = {}
+    for container_path, local_path in data.items():
+        if not isinstance(container_path, str) or not isinstance(local_path, str):
+            raise ValueError(
+                f"'simple.config' entries must map strings to strings in {source_file}"
+            )
+        config_data[container_path] = local_path
+    return config_data
+
+
+def _parse_simple_config(
+    data: dict,
+    source_file: Path,
+    variables: dict[str, TemplateValue],
+    table_index: int = 0,
+    default_namespace: str | None = None,
+    default_image: str | None = None,
+) -> SimpleConfig:
+    """Parse a simple app configuration from TOML data."""
+    validate_known_fields(
+        "[[simple]]",
+        data,
+        {
+            "name",
+            "namespace",
+            "image",
+            "args",
+            "iam-role",
+            "k8s-role",
+            "service-account-annotations",
+            "config",
+            "external-secret",
+            "external-secrets",
+            "custom-token-audiences",
+            "extra-resources",
+            "replicas",
+            "arch",
+            "random-secret",
+            "random-secrets",
+        },
+        source_file,
+        table_index,
+    )
+
+    if "namespace" not in data and default_namespace is None:
+        raise ValueError(f"Missing required field 'namespace' in {source_file}")
+
+    if default_image is not None and "image" in data:
+        raise ValueError(
+            f"Cannot specify 'image' in {source_file} when generate(image=...) is used"
+        )
+    if "image" not in data and default_image is None:
+        raise ValueError(f"Missing required field 'image' in {source_file}")
+
+    iam_role = data.get("iam-role")
+    if iam_role is not None and not isinstance(iam_role, str):
+        raise ValueError(f"'iam-role' must be a string in {source_file}")
+
+    k8s_role = data.get("k8s-role")
+    if k8s_role is not None and not isinstance(k8s_role, str):
+        raise ValueError(f"'k8s-role' must be a string in {source_file}")
+
+    service_account_annotations = data.get("service-account-annotations")
+    if service_account_annotations is not None and (
+        not isinstance(service_account_annotations, dict)
+        or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in service_account_annotations.items()
+        )
+    ):
+        raise ValueError(
+            f"'service-account-annotations' must be a table mapping strings to "
+            f"strings in {source_file}"
+        )
+
+    if (
+        iam_role is not None
+        and service_account_annotations is not None
+        and IAM_ROLE_ANNOTATION in service_account_annotations
+    ):
+        raise ValueError(
+            f"'service-account-annotations' cannot set '{IAM_ROLE_ANNOTATION}' when "
+            f"'iam-role' is also specified in {source_file}; use one or the other"
+        )
+
+    arch = data.get("arch")
+    if arch is not None and not isinstance(arch, str):
+        raise ValueError(f"'arch' must be a string in {source_file}")
+
+    args = data.get("args")
+    if args is not None and (
+        not isinstance(args, list) or not all(isinstance(arg, str) for arg in args)
+    ):
+        raise ValueError(f"'args' must be a list of strings in {source_file}")
+
+    custom_token_audiences = data.get("custom-token-audiences")
+    if custom_token_audiences is not None and (
+        not isinstance(custom_token_audiences, list)
+        or not all(isinstance(audience, str) for audience in custom_token_audiences)
+    ):
+        raise ValueError(
+            f"'custom-token-audiences' must be a list of strings in {source_file}"
+        )
+
+    external_secrets = _parse_external_secrets(data, source_file)
+
+    random_secrets = _parse_random_secrets(data, source_file)
+
+    namespace = data.get("namespace", default_namespace)
+    image = data.get("image", default_image)
+    name = data.get("name", namespace)
+    extra_resources = None
+    if "extra-resources" in data:
+        extra_resources = source_file.parent / data["extra-resources"]
+
+    return SimpleConfig(
+        name=name,
+        namespace=namespace,
+        image=image,
+        args=args,
+        iam_role=iam_role,
+        k8s_role=k8s_role,
+        service_account_annotations=service_account_annotations,
+        config=_parse_config_files(data.get("config"), source_file),
+        external_secrets=external_secrets,
+        custom_token_audiences=custom_token_audiences,
+        variables=variables.copy(),
+        extra_resources=extra_resources,
+        replicas=data.get("replicas", DEFAULT_REPLICA_COUNT),
+        arch=arch,
+        random_secrets=random_secrets,
+    )
+
+
+def _parse_external_secrets(data: dict, source_file: Path) -> list[str] | None:
+    """Normalize singular and plural external secret fields into mount paths.
+
+    A single mount path may also be given as a bare plural-field string for
+    backwards compatibility.
+    """
+    external_secret = data.get("external-secret")
+    external_secrets = data.get("external-secrets")
+
+    if external_secret is not None and external_secrets is not None:
+        raise ValueError(
+            f"Cannot specify both 'external-secret' and 'external-secrets' in {source_file}"
+        )
+
+    if external_secret is not None:
+        if not isinstance(external_secret, str):
+            raise ValueError(f"'external-secret' must be a string in {source_file}")
+        return [external_secret]
+
+    if external_secrets is None:
+        return None
+
+    if isinstance(external_secrets, str):
+        return [external_secrets]
+
+    if not isinstance(external_secrets, list):
+        raise ValueError(
+            f"'external-secrets' must be a string or list of strings in {source_file}"
+        )
+
+    mount_paths: list[str] = []
+    for mount_path in external_secrets:
+        if not isinstance(mount_path, str):
+            raise ValueError(
+                f"'external-secrets' must be a string or list of strings in "
+                f"{source_file}"
+            )
+        mount_paths.append(mount_path)
+    return mount_paths
+
+
+def _parse_random_secrets(data: dict, source_file: Path) -> list[str] | None:
+    """Normalize the 'random-secret'/'random-secrets' fields into a list of names.
+
+    'random-secret' names a single secret key; 'random-secrets' names a list.
+    Specifying both is an error.
+    """
+    random_secret = data.get("random-secret")
+    random_secrets = data.get("random-secrets")
+
+    if random_secret is not None and random_secrets is not None:
+        raise ValueError(
+            f"Cannot specify both 'random-secret' and 'random-secrets' in {source_file}"
+        )
+
+    if random_secret is not None:
+        if not isinstance(random_secret, str):
+            raise ValueError(f"'random-secret' must be a string in {source_file}")
+        return [random_secret]
+
+    if random_secrets is not None:
+        if not isinstance(random_secrets, list) or not all(
+            isinstance(secret, str) for secret in random_secrets
+        ):
+            raise ValueError(
+                f"'random-secrets' must be a list of strings in {source_file}"
+            )
+        return random_secrets
+
+    return None
+
+
+def _inject_configmaps(
+    docs: list[dict],
+    config: SimpleConfig,
+    k8s_name: str,
+    context: dict[str, Any],
+) -> None:
+    if not config.config:
+        return
+
+    configmaps = make_configmaps(k8s_name, config.config, context)
+    checksum = config_checksum(configmaps)
+    for cm in configmaps:
+        cm.setdefault("metadata", {})["namespace"] = config.namespace
+    docs.extend(configmaps)
+
+    mount_groups = {
+        str(Path(container_path).parent) for container_path in config.config
+    }
+    for doc in docs:
+        if doc.get("kind") != "Deployment":
+            continue
+
+        doc.setdefault("spec", {}).setdefault("template", {}).setdefault(
+            "metadata", {}
+        ).setdefault("annotations", {})["checksum/config"] = checksum
+        pod_spec = (
+            doc.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+        )
+        for mount_path in sorted(mount_groups):
+            cm_name = f"{k8s_name}-{configmap_suffix_from_mount_path(mount_path)}"
+            for container in pod_spec.get("containers", []):
+                container.setdefault("volumeMounts", []).append(
+                    {"name": cm_name, "mountPath": mount_path}
+                )
+            pod_spec.setdefault("volumes", []).append(
+                {"name": cm_name, "configMap": {"name": cm_name}}
+            )
+
+
+def _inject_external_secrets(docs: list[dict], config: SimpleConfig) -> None:
+    """Mount externally managed Secrets at the configured paths.
+
+    Each mount path names the Secret it mounts, so ``/email-password`` mounts the
+    Secret ``email-password`` and ``/db/credentials`` mounts ``db-credentials``.
+    """
+    if not config.external_secrets:
+        return
+
+    for mount_path in config.external_secrets:
+        secret_name = secret_name_from_mount_path(mount_path)
+        for doc in docs:
+            if doc.get("kind") != "Deployment":
+                continue
+
+            pod_spec = (
+                doc.setdefault("spec", {})
+                .setdefault("template", {})
+                .setdefault("spec", {})
+            )
+            for container in pod_spec.get("containers", []):
+                container.setdefault("volumeMounts", []).append(
+                    {"name": secret_name, "mountPath": mount_path}
+                )
+            pod_spec.setdefault("volumes", []).append(
+                {"name": secret_name, "secret": {"secretName": secret_name}}
+            )
+
+
+RANDOM_SECRETS_MOUNT_PATH = "/random-secrets"
+
+
+def _inject_random_secrets(
+    docs: list[dict],
+    config: SimpleConfig,
+    k8s_name: str,
+) -> None:
+    """Emit a RandomSecret and mount its generated Secret at /random-secrets.
+
+    The randomsecret controller (https://github.com/portswigger/randomsecret)
+    reconciles a RandomSecret into a Secret of the same name in the same
+    namespace, populating one entry per name in ``spec.secrets``.
+    """
+    if not config.random_secrets:
+        return
+
+    docs.append(
+        {
+            "apiVersion": "noa.re/v1alpha1",
+            "kind": "RandomSecret",
+            "metadata": {"name": k8s_name, "namespace": config.namespace},
+            "spec": {"secrets": [{"name": secret} for secret in config.random_secrets]},
+        }
+    )
+
+    for doc in docs:
+        if doc.get("kind") != "Deployment":
+            continue
+
+        pod_spec = (
+            doc.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+        )
+        for container in pod_spec.get("containers", []):
+            container.setdefault("volumeMounts", []).append(
+                {"name": "random-secrets", "mountPath": RANDOM_SECRETS_MOUNT_PATH}
+            )
+        pod_spec.setdefault("volumes", []).append(
+            {"name": "random-secrets", "secret": {"secretName": k8s_name}}
+        )
+
+
+def generate_simple(
+    config: SimpleConfig,
+    output_dir: Path,
+    images: dict[str, str] | None = None,
+    _templates_override: Path | None = None,  # for testing only
+) -> set[Path]:
+    """Generate manifests for a simple app from plugin-owned Mustache templates."""
+    import pystache
+    from pystache.common import MissingTags
+
+    # Read templates at generation time so a replaced plugin checkout takes effect.
+    if _templates_override is not None:
+        templates_dir = _templates_override
+    else:
+        templates_dir = Path(__file__).parent / "templates" / "simple"
+
+    context: dict[str, Any] = {
+        **(images or {}),
+        **config.variables,
+        "name": config.name,
+        "k8s_name": make_k8s_name(config.name),
+        "namespace": config.namespace,
+        "replicas": config.replicas,
+    }
+    context["image"] = config.image
+    if config.args:
+        context["args"] = config.args
+        context["container_args"] = {
+            "items": [{"yaml": json.dumps(arg)} for arg in config.args]
+        }
+    if config.arch:
+        context["arch"] = config.arch
+    if config.iam_role or config.k8s_role or config.service_account_annotations:
+        context["service_account"] = True
+    renderer = pystache.Renderer(missing_tags=MissingTags.strict)
+    if config.iam_role:
+        context["iam_role"] = renderer.render(config.iam_role, context)
+    if config.k8s_role:
+        context["k8s_role"] = renderer.render(config.k8s_role, context)
+    if config.iam_role or config.service_account_annotations:
+        context["service_account_has_annotations"] = True
+    if config.service_account_annotations:
+        context["service_account_annotations"] = [
+            {"key": key, "value": json.dumps(renderer.render(value, context))}
+            for key, value in config.service_account_annotations.items()
+        ]
+
+    docs: list[dict] = []
+    for template_file in sorted(templates_dir.glob("*.yaml")):
+        if template_file.name.startswith("_"):
+            continue
+
+        rendered = pystache.render(template_file.read_text(), context)
+        for doc in yaml.safe_load_all(rendered):
+            if doc:
+                docs.append(doc)
+
+    for doc in docs:
+        kind = doc.get("kind")
+        if kind and kind not in CLUSTER_SCOPED_KINDS:
+            doc.setdefault("metadata", {})["namespace"] = config.namespace
+
+    if config.extra_resources:
+        renderer = pystache.Renderer(missing_tags=MissingTags.strict)
+        for yaml_file in sorted(config.extra_resources.glob("*.yaml")):
+            rendered = renderer.render(yaml_file.read_text(), context)
+            for doc in yaml.safe_load_all(rendered):
+                if not doc:
+                    continue
+                kind = doc.get("kind")
+                if (
+                    kind
+                    and kind not in CLUSTER_SCOPED_KINDS
+                    and "namespace" not in doc.get("metadata", {})
+                ):
+                    doc.setdefault("metadata", {})["namespace"] = config.namespace
+                docs.append(doc)
+
+    k8s_name = make_k8s_name(config.name)
+    _inject_configmaps(docs, config, k8s_name, context)
+
+    _inject_external_secrets(docs, config)
+
+    if config.random_secrets:
+        _inject_random_secrets(docs, config, k8s_name)
+
+    if config.custom_token_audiences:
+        for doc in docs:
+            inject_custom_token_projection(doc, config.custom_token_audiences)
+
+    return write_documents(docs, output_dir, config.namespace, config.name)

--- a/plugins/templates/simple/deployment.yaml
+++ b/plugins/templates/simple/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{k8s_name}}
+  labels:
+    app: {{k8s_name}}
+spec:
+  replicas: {{replicas}}
+  selector:
+    matchLabels:
+      app: {{k8s_name}}
+  template:
+    metadata:
+      labels:
+        app: {{k8s_name}}
+    spec:
+{{#service_account}}
+      serviceAccountName: {{name}}
+{{/service_account}}
+{{#arch}}
+      nodeSelector:
+        kubernetes.io/arch: {{.}}
+{{/arch}}
+      containers:
+        - name: {{k8s_name}}
+          image: {{image}}
+          ports:
+            - name: http
+              containerPort: 8080
+{{#container_args}}
+          args:
+{{#items}}
+            - {{{yaml}}}
+{{/items}}
+{{/container_args}}

--- a/plugins/templates/simple/rolebinding.yaml
+++ b/plugins/templates/simple/rolebinding.yaml
@@ -1,0 +1,14 @@
+{{#k8s_role}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{name}}-{{k8s_role}}
+subjects:
+  - kind: ServiceAccount
+    name: {{name}}
+    namespace: {{namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{k8s_role}}
+{{/k8s_role}}

--- a/plugins/templates/simple/service.yaml
+++ b/plugins/templates/simple/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{k8s_name}}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{k8s_name}}
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/plugins/templates/simple/serviceaccount.yaml
+++ b/plugins/templates/simple/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{#service_account}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{name}}
+{{#service_account_has_annotations}}
+  annotations:
+{{#iam_role}}
+    eks.amazonaws.com/role-arn: {{iam_role}}
+{{/iam_role}}
+{{#service_account_annotations}}
+    {{key}}: {{{value}}}
+{{/service_account_annotations}}
+{{/service_account_has_annotations}}
+{{/service_account}}

--- a/plugins/tests/test_helm_block.py
+++ b/plugins/tests/test_helm_block.py
@@ -1,0 +1,1683 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the [[helm]] config block."""
+
+import re
+import textwrap
+from collections.abc import Sequence
+from pathlib import Path
+from threading import Barrier, Lock
+from time import sleep
+from typing import Any
+from unittest import mock
+
+import pytest
+import yaml
+from manifest_builder.blocks import ConfigBlock
+from manifest_builder.config import ManifestConfig, load_configs, resolve_configs
+from manifest_builder.generator import generate_manifests
+from manifest_builder.helmfile import Helmfile, HelmfileRelease, HelmfileRepository
+from pystache.context import KeyNotFoundError
+
+from helm import ChartConfig, HelmBlock, _generate_helm_manifests
+
+NAMESPACED_YAML = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+  namespace: production
+spec: {}
+"""
+
+
+def write_toml(directory: Path, name: str, content: str) -> Path:
+    path = directory / name
+    path.write_text(textwrap.dedent(content))
+    return path
+
+
+def all_configs(blocks: Sequence[ConfigBlock]) -> tuple[ManifestConfig, ...]:
+    return tuple(config for block in blocks for config in block.iter_configs())
+
+
+def only_config(blocks: Sequence[ConfigBlock]) -> ManifestConfig:
+    (config,) = all_configs(blocks)
+    return config
+
+
+def config_blocks() -> list[ConfigBlock[Any]]:
+    """This directory's helm block, loaded the way a real run loads it."""
+    return [HelmBlock()]
+
+
+def load_test_configs(config_dir: Path) -> Sequence[ConfigBlock]:
+    return load_configs(config_dir, config_blocks())
+
+
+def manifest_configs(
+    *,
+    helm: list[ChartConfig] | None = None,
+) -> list[ConfigBlock[Any]]:
+    return [HelmBlock(helm)]
+
+
+def _make_helmfile() -> Helmfile:
+    return Helmfile(
+        repositories=[
+            HelmfileRepository(name="myrepo", url="https://charts.example.com")
+        ],
+        releases=[
+            HelmfileRelease(
+                name="myapp",
+                chart="myrepo/myapp",
+                version="1.2.3",
+                namespace="default",
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+
+
+def test_values_resolved_relative_to_config_dir(tmp_path: Path) -> None:
+    """Values paths must be resolved relative to the TOML file's directory."""
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        values = ["myapp/values.yaml"]
+        """,
+    )
+
+    configs = load_test_configs(conf_dir)
+    assert len(all_configs(configs)) == 1
+    config = only_config(configs)
+    assert isinstance(config, ChartConfig)
+    assert config.values == [conf_dir / "myapp/values.yaml"]
+
+
+def test_values_resolved_relative_to_custom_config_dir(tmp_path: Path) -> None:
+    """Specifying a different -c directory changes where values are resolved."""
+    conf_a = tmp_path / "conf-a"
+    conf_a.mkdir()
+    conf_b = tmp_path / "conf-b"
+    conf_b.mkdir()
+
+    for conf_dir in (conf_a, conf_b):
+        write_toml(
+            conf_dir,
+            "config.toml",
+            """\
+            [[helm]]
+            namespace = "default"
+            chart = "./charts/myapp"
+            name = "myapp"
+            values = ["values.yaml"]
+            """,
+        )
+
+    configs_a = load_test_configs(conf_a)
+    configs_b = load_test_configs(conf_b)
+
+    config_a = only_config(configs_a)
+    config_b = only_config(configs_b)
+    assert isinstance(config_a, ChartConfig)
+    assert isinstance(config_b, ChartConfig)
+    assert config_a.values == [conf_a / "values.yaml"]
+    assert config_b.values == [conf_b / "values.yaml"]
+    assert config_a.values != config_b.values
+
+
+def test_values_single_string_treated_as_list(tmp_path: Path) -> None:
+    """A bare string for 'values' is treated as a single-element list."""
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        values = "myapp/values.yaml"
+        """,
+    )
+
+    configs = load_test_configs(conf_dir)
+    config = only_config(configs)
+    assert isinstance(config, ChartConfig)
+    assert config.values == [conf_dir / "myapp/values.yaml"]
+
+
+def test_values_empty_when_not_specified(tmp_path: Path) -> None:
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        """,
+    )
+
+    configs = load_test_configs(conf_dir)
+    config = only_config(configs)
+    assert isinstance(config, ChartConfig)
+    assert config.values == []
+
+
+def test_load_chart_config_with_name_override(tmp_path: Path) -> None:
+    """Helm configs can override the release name passed to Helm."""
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        release = "myapp"
+        name-override = "myapp-rendered"
+        """,
+    )
+
+    configs = load_test_configs(conf_dir)
+    config = only_config(configs)
+
+    assert isinstance(config, ChartConfig)
+    assert config.name == "myapp"
+    assert config.release == "myapp"
+    assert config.name_override == "myapp-rendered"
+
+
+def test_load_chart_config_with_config(tmp_path: Path) -> None:
+    """Helm config can specify ConfigMap keys with local file paths."""
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    config_file = conf_dir / "app.conf"
+    config_file.write_text("debug=true\n")
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        config = { "app.conf" = "app.conf" }
+        """,
+    )
+
+    configs = load_test_configs(conf_dir)
+    config = only_config(configs)
+
+    assert isinstance(config, ChartConfig)
+    assert config.config == {"app.conf": config_file}
+
+
+def test_load_chart_config_with_custom_token_audiences(tmp_path: Path) -> None:
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        custom-token-audiences = ["vault", "api"]
+        """,
+    )
+
+    config = only_config(load_test_configs(conf_dir))
+
+    assert isinstance(config, ChartConfig)
+    assert config.custom_token_audiences == ["vault", "api"]
+
+
+def test_load_chart_config_with_custom_token_audience(tmp_path: Path) -> None:
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        custom-token-audience = "vault"
+        """,
+    )
+
+    config = only_config(load_test_configs(conf_dir))
+
+    assert isinstance(config, ChartConfig)
+    assert config.custom_token_audiences == ["vault"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "custom-token-audience",
+            '["vault"]',
+            "'custom-token-audience' must be a string",
+        ),
+        (
+            "custom-token-audiences",
+            '"vault"',
+            "'custom-token-audiences' must be a list of strings",
+        ),
+    ],
+)
+def test_load_chart_config_custom_token_audience_type_validation(
+    tmp_path: Path, field: str, value: str, message: str
+) -> None:
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        f"""\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        {field} = {value}
+        """,
+    )
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        load_test_configs(conf_dir)
+
+
+def test_load_chart_config_custom_token_audience_fields_are_mutually_exclusive(
+    tmp_path: Path,
+) -> None:
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        custom-token-audience = "vault"
+        custom-token-audiences = ["api"]
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot specify both 'custom-token-audience' and "
+        "'custom-token-audiences'",
+    ):
+        load_test_configs(conf_dir)
+
+
+def test_load_chart_config_unknown_field_raises(tmp_path: Path) -> None:
+    """Unknown Helm fields should fail before generation."""
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        value = ["values.yaml"]
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Unknown field in \[\[helm\]\]: 'value' on line 5",
+    ):
+        load_test_configs(conf_dir)
+
+
+def test_variables_are_loaded_for_helm_configs(tmp_path: Path) -> None:
+    """Top-level variables should be attached to helm configs from the same TOML file."""
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+        [variables]
+        domain = "example.com"
+        replica_count = 3
+        use_tls = true
+
+        [[helm]]
+        namespace = "default"
+        chart = "./charts/myapp"
+        name = "myapp"
+        values = ["values.yaml"]
+        """,
+    )
+
+    configs = load_test_configs(conf_dir)
+    assert len(all_configs(configs)) == 1
+    config = only_config(configs)
+    assert isinstance(config, ChartConfig)
+    assert config.variables == {
+        "domain": "example.com",
+        "replica_count": 3,
+        "use_tls": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+
+
+def test_validate_config_missing_values_file(tmp_path: Path) -> None:
+    config = ChartConfig(
+        name="myapp",
+        namespace="default",
+        chart="./charts/myapp",
+        repo=None,
+        version=None,
+        values=[tmp_path / "nonexistent.yaml"],
+        release=None,
+    )
+    with pytest.raises(ValueError, match="Values file not found"):
+        HelmBlock().validate(config, tmp_path)
+
+
+def test_validate_config_existing_values_file(tmp_path: Path) -> None:
+    values_file = tmp_path / "values.yaml"
+    values_file.write_text("key: value\n")
+
+    config = ChartConfig(
+        name="myapp",
+        namespace="default",
+        chart=None,
+        repo=None,
+        version=None,
+        values=[values_file],
+        release="myapp",
+    )
+    HelmBlock().validate(config, tmp_path)  # should not raise
+
+
+def test_validate_config_missing_local_chart(tmp_path: Path) -> None:
+    config = ChartConfig(
+        name="myapp",
+        namespace="default",
+        chart="./charts/myapp",
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+    )
+    with pytest.raises(ValueError, match="Local chart path not found"):
+        HelmBlock().validate(config, tmp_path)
+
+
+def test_load_configs_both_release_and_chart_raises(tmp_path: Path) -> None:
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        name = "myapp"
+        chart = "./charts/myapp"
+        release = "myapp"
+        """,
+    )
+    with pytest.raises(ValueError, match="Cannot specify both"):
+        load_test_configs(conf)
+
+
+def test_load_configs_neither_release_nor_chart_raises(tmp_path: Path) -> None:
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[helm]]
+        namespace = "default"
+        name = "myapp"
+        """,
+    )
+    with pytest.raises(ValueError, match="Must specify either"):
+        load_test_configs(conf)
+
+
+def test_resolve_configs_fills_in_chart_and_repo(tmp_path: Path) -> None:
+    config = ChartConfig(
+        name="myapp",
+        namespace="default",
+        chart=None,
+        repo=None,
+        version=None,
+        values=[],
+        release="myapp",
+        name_override="myapp-rendered",
+        custom_token_audiences=["vault"],
+    )
+    resolved = resolve_configs(manifest_configs(helm=[config]), _make_helmfile())
+    assert len(all_configs(resolved)) == 1
+    resolved_config = only_config(resolved)
+    assert isinstance(resolved_config, ChartConfig)
+    assert resolved_config.chart == "myapp"
+    assert resolved_config.repo == "https://charts.example.com"
+    assert resolved_config.version == "1.2.3"
+    assert resolved_config.name_override == "myapp-rendered"
+    assert resolved_config.custom_token_audiences == ["vault"]
+
+
+def test_resolve_configs_no_helmfile_raises_when_release_present(
+    tmp_path: Path,
+) -> None:
+    config = ChartConfig(
+        name="myapp",
+        namespace="default",
+        chart=None,
+        repo=None,
+        version=None,
+        values=[],
+        release="myapp",
+    )
+    with pytest.raises(ValueError, match="no releases.yaml was found"):
+        resolve_configs(manifest_configs(helm=[config]), None)
+
+
+def test_resolve_configs_unknown_release_raises() -> None:
+    config = ChartConfig(
+        name="unknown",
+        namespace="default",
+        chart=None,
+        repo=None,
+        version=None,
+        values=[],
+        release="unknown",
+    )
+    with pytest.raises(ValueError, match="not found in releases.yaml"):
+        resolve_configs(manifest_configs(helm=[config]), _make_helmfile())
+
+
+def test_resolve_configs_oci_repository() -> None:
+    """OCI repositories should be resolved to a full OCI URL chart and no repo."""
+    helmfile = Helmfile(
+        repositories=[
+            HelmfileRepository(
+                name="envoyproxy",
+                url="docker.io/envoyproxy",
+                oci=True,
+            )
+        ],
+        releases=[
+            HelmfileRelease(
+                name="envoy-gateway",
+                chart="envoyproxy/gateway-helm",
+                version="v1.7.0",
+                namespace="default",
+            )
+        ],
+    )
+    config = ChartConfig(
+        name="envoy-gateway",
+        namespace="default",
+        chart=None,
+        repo=None,
+        version=None,
+        values=[],
+        release="envoy-gateway",
+    )
+    resolved = resolve_configs(manifest_configs(helm=[config]), helmfile)
+    assert len(all_configs(resolved)) == 1
+    resolved_config = only_config(resolved)
+    assert isinstance(resolved_config, ChartConfig)
+    assert resolved_config.chart == "oci://docker.io/envoyproxy/gateway-helm"
+    assert resolved_config.repo is None
+    assert resolved_config.version == "v1.7.0"
+
+
+def test_resolve_configs_passthrough_for_direct_chart() -> None:
+    config = ChartConfig(
+        name="myapp",
+        namespace="default",
+        chart="./charts/myapp",
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        extra_resources=None,
+    )
+    resolved = resolve_configs(manifest_configs(helm=[config]), None)
+    assert all_configs(resolved) == (config,)
+
+
+def test_load_chart_config_with_extra_resources(tmp_path: Path) -> None:
+    """Chart config can specify a directory with extra YAML resources."""
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    resources_dir = conf_dir / "resources"
+    resources_dir.mkdir()
+
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+[[helm]]
+name = "my-chart"
+namespace = "default"
+chart = "./charts/myapp"
+extra-resources = "resources"
+""",
+    )
+
+    configs = load_test_configs(conf_dir)
+    config = only_config(configs)
+    assert isinstance(config, ChartConfig)
+    assert config.extra_resources == resources_dir
+
+
+def test_validate_config_chart_extra_resources_missing_directory(
+    tmp_path: Path,
+) -> None:
+    """Validation should fail if extra_resources directory doesn't exist."""
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart="./charts/myapp",
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        extra_resources=tmp_path / "nonexistent",
+    )
+    with pytest.raises(ValueError, match="Extra resources directory not found"):
+        HelmBlock().validate(config, tmp_path)
+
+
+def test_validate_config_chart_config_missing_file(tmp_path: Path) -> None:
+    """Validation should fail if a Helm config file doesn't exist."""
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart="./charts/myapp",
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        config={"app.conf": tmp_path / "missing.conf"},
+    )
+    with pytest.raises(ValueError, match="Config file not found for chart"):
+        HelmBlock().validate(config, tmp_path)
+
+
+def test_validate_config_chart_extra_resources_not_a_directory(tmp_path: Path) -> None:
+    """Validation should fail if extra_resources path is not a directory."""
+    not_a_dir = tmp_path / "file.txt"
+    not_a_dir.write_text("content")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart="./charts/myapp",
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        extra_resources=not_a_dir,
+    )
+    with pytest.raises(ValueError, match="Extra resources path is not a directory"):
+        HelmBlock().validate(config, tmp_path)
+
+
+def test_load_chart_config_with_init(tmp_path: Path) -> None:
+    """Chart config can specify an init script to inject as initContainer."""
+    conf_dir = tmp_path / "conf"
+    conf_dir.mkdir()
+    script_file = conf_dir / "setup.sh"
+    script_file.write_text("#!/bin/sh\necho 'initializing'")
+
+    write_toml(
+        conf_dir,
+        "config.toml",
+        """\
+[[helm]]
+name = "my-chart"
+namespace = "default"
+chart = "./charts/myapp"
+init = "setup.sh"
+""",
+    )
+
+    configs = load_test_configs(conf_dir)
+    config = only_config(configs)
+    assert isinstance(config, ChartConfig)
+    assert config.init == script_file
+
+
+def test_validate_config_chart_init_missing_file(tmp_path: Path) -> None:
+    """Validation should fail if init script file doesn't exist."""
+    # Create the chart directory so that check passes
+    chart_dir = tmp_path / "charts" / "myapp"
+    chart_dir.mkdir(parents=True)
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart="./charts/myapp",
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        init=tmp_path / "nonexistent.sh",
+    )
+    with pytest.raises(ValueError, match="init script not found"):
+        HelmBlock().validate(config, tmp_path)
+
+
+def test_generate_manifests_renders_helm_configs_concurrently(tmp_path: Path) -> None:
+    """Helm renders should overlap without racing chart cache access."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    configs = [
+        ChartConfig(
+            name=name,
+            namespace="default",
+            chart="chart",
+            repo="https://charts.example.com",
+            version=None,
+            values=[],
+            release=None,
+        )
+        for name in ("first", "second")
+    ]
+    render_barrier = Barrier(len(configs))
+    counter_lock = Lock()
+    active_pulls = 0
+    max_active_pulls = 0
+
+    def pull(**kwargs: object) -> Path:
+        nonlocal active_pulls, max_active_pulls
+        with counter_lock:
+            active_pulls += 1
+            max_active_pulls = max(max_active_pulls, active_pulls)
+        sleep(0.02)
+        with counter_lock:
+            active_pulls -= 1
+        return chart_dir
+
+    def render(**kwargs: object) -> str:
+        render_barrier.wait(timeout=5)
+        release_name = kwargs["release_name"]
+        return f"""\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {release_name}
+data: {{}}
+"""
+
+    with (
+        mock.patch("helm.pull_chart", side_effect=pull),
+        mock.patch("helm.run_helm_template", side_effect=render),
+    ):
+        written = generate_manifests(
+            [HelmBlock(configs)],
+            tmp_path / "out",
+            repo_root=tmp_path,
+        )
+
+    assert {path.name for path in written} >= {
+        "configmap-first.yaml",
+        "configmap-second.yaml",
+    }
+    assert max_active_pulls == 1
+
+
+# ---------------------------------------------------------------------------
+# _generate_helm_manifests CRD handling
+# ---------------------------------------------------------------------------
+
+
+def test_generate_helm_manifests_uses_name_override(tmp_path: Path) -> None:
+    """The Helm invocation should use the configured release name override."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    config = ChartConfig(
+        name="release-from-helmfile",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release="release-from-helmfile",
+        name_override="rendered-release",
+    )
+
+    with mock.patch("helm.run_helm_template", return_value="") as run_helm_template:
+        paths = _generate_helm_manifests(
+            config, tmp_path / "output", tmp_path / "charts"
+        )
+
+    assert paths == set()
+    run_helm_template.assert_called_once_with(
+        release_name="rendered-release",
+        chart=str(chart_dir),
+        namespace="default",
+        values_files=[],
+    )
+
+
+def test_generate_helm_manifests_writes_crds_returned_by_helm(
+    tmp_path: Path,
+) -> None:
+    """CRDs emitted by helm template are written as cluster-scoped manifests."""
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+    charts_dir.mkdir()
+
+    chart_dir = charts_dir / "my-chart"
+    chart_dir.mkdir()
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart="my-chart",
+        repo="https://example.com",
+        version="1.0.0",
+        values=[],
+        release=None,
+    )
+
+    templated_manifest = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: MyResource
+  scope: Namespaced
+"""
+
+    with (
+        mock.patch(
+            "helm.pull_chart",
+            return_value=chart_dir,
+        ),
+        mock.patch(
+            "helm.run_helm_template",
+            return_value=templated_manifest,
+        ),
+    ):
+        paths = _generate_helm_manifests(config, output_dir, charts_dir)
+
+    crd_output = (
+        output_dir / "cluster" / "customresourcedefinition-myresources.example.com.yaml"
+    )
+    deployment_output = output_dir / "default" / "deployment-my-app.yaml"
+
+    assert crd_output.exists()
+    assert deployment_output.exists()
+    assert len(paths) == 2
+
+
+def test_generate_helm_manifests_does_not_copy_crds_from_chart_directory(
+    tmp_path: Path,
+) -> None:
+    """CRDs are not copied separately from the chart filesystem."""
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+    charts_dir.mkdir()
+
+    chart_dir = charts_dir / "my-chart"
+    chart_dir.mkdir()
+    crds_dir = chart_dir / "crds"
+    crds_dir.mkdir()
+    crd_yaml = crds_dir / "crd.yaml"
+    crd_yaml.write_text("""\
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: myresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: MyResource
+  scope: Namespaced
+""")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart="my-chart",
+        repo="https://example.com",
+        version="1.0.0",
+        values=[],
+        release=None,
+    )
+
+    with (
+        mock.patch(
+            "helm.pull_chart",
+            return_value=chart_dir,
+        ),
+        mock.patch(
+            "helm.run_helm_template",
+            return_value="",
+        ),
+    ):
+        paths = _generate_helm_manifests(config, output_dir, charts_dir)
+
+    crd_output = (
+        output_dir / "cluster" / "customresourcedefinition-myresources.example.com.yaml"
+    )
+    assert not crd_output.exists()
+    assert paths == set()
+
+
+def test_generate_helm_manifests_init_single_deployment(tmp_path: Path) -> None:
+    """init script should be injected as initContainer when exactly one Deployment exists."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+
+    script_file = tmp_path / "setup.sh"
+    script_file.write_text("mkdir -p /data && chown 65532:65532 /data")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        init=script_file,
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+
+    deployment_yaml = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        emptyDir: {}
+"""
+
+    images = {"alpine_image": "alpine:3.21"}
+
+    with (
+        mock.patch(
+            "helm.pull_chart",
+            return_value=chart_dir,
+        ),
+        mock.patch(
+            "helm.run_helm_template",
+            return_value=deployment_yaml,
+        ),
+    ):
+        paths = _generate_helm_manifests(config, output_dir, charts_dir, images=images)
+
+    assert len(paths) == 1
+    deployment_file = output_dir / "default" / "deployment-my-app.yaml"
+    assert deployment_file.exists()
+
+    doc = yaml.safe_load(deployment_file.read_text())
+    assert "initContainers" in doc["spec"]["template"]["spec"]
+    init_containers = doc["spec"]["template"]["spec"]["initContainers"]
+    assert len(init_containers) == 1
+    assert init_containers[0]["name"] == "setup"
+    assert init_containers[0]["image"] == "alpine:3.21"
+    assert init_containers[0]["command"] == [
+        "/bin/sh",
+        "-c",
+        "mkdir -p /data && chown 65532:65532 /data",
+    ]
+    assert len(init_containers[0]["volumeMounts"]) == 1
+    assert init_containers[0]["volumeMounts"][0]["name"] == "data"
+
+
+def test_generate_helm_manifests_init_multiple_deployments(tmp_path: Path) -> None:
+    """init should fail with ValueError if more than one Deployment exists."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+
+    script_file = tmp_path / "setup.sh"
+    script_file.write_text("echo 'init'")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        init=script_file,
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+
+    two_deployments = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app2
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+"""
+
+    images = {"alpine_image": "alpine:3.21"}
+
+    with (
+        mock.patch(
+            "helm.pull_chart",
+            return_value=chart_dir,
+        ),
+        mock.patch(
+            "helm.run_helm_template",
+            return_value=two_deployments,
+        ),
+        pytest.raises(
+            ValueError, match="init requires exactly one Deployment.*found 2"
+        ),
+    ):
+        _generate_helm_manifests(config, output_dir, charts_dir, images=images)
+
+
+def test_generate_helm_manifests_init_no_deployments(tmp_path: Path) -> None:
+    """init should fail with ValueError if no Deployments exist."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+
+    script_file = tmp_path / "setup.sh"
+    script_file.write_text("echo 'init'")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        init=script_file,
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+
+    service_yaml = """\
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: myapp
+"""
+
+    images = {"alpine_image": "alpine:3.21"}
+
+    with (
+        mock.patch(
+            "helm.pull_chart",
+            return_value=chart_dir,
+        ),
+        mock.patch(
+            "helm.run_helm_template",
+            return_value=service_yaml,
+        ),
+        pytest.raises(
+            ValueError, match="init requires exactly one Deployment.*found 0"
+        ),
+    ):
+        _generate_helm_manifests(config, output_dir, charts_dir, images=images)
+
+
+def test_generate_helm_manifests_init_missing_alpine_image(tmp_path: Path) -> None:
+    """init should fail if alpine_image is not in images dict."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+
+    script_file = tmp_path / "setup.sh"
+    script_file.write_text("echo 'init'")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        init=script_file,
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+
+    deployment_yaml = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+"""
+
+    images = {}  # missing alpine_image
+
+    with (
+        mock.patch(
+            "helm.pull_chart",
+            return_value=chart_dir,
+        ),
+        mock.patch(
+            "helm.run_helm_template",
+            return_value=deployment_yaml,
+        ),
+        pytest.raises(
+            ValueError,
+            match="init requires 'alpine_image' to be defined in images.toml",
+        ),
+    ):
+        _generate_helm_manifests(config, output_dir, charts_dir, images=images)
+
+
+def test_generate_helm_manifests_init_no_volumemounts(tmp_path: Path) -> None:
+    """init container should have no volumeMounts if containers have none."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+
+    script_file = tmp_path / "setup.sh"
+    script_file.write_text("echo 'init'")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        init=script_file,
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+
+    deployment_yaml = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+"""
+
+    images = {"alpine_image": "alpine:3.21"}
+
+    with (
+        mock.patch(
+            "helm.pull_chart",
+            return_value=chart_dir,
+        ),
+        mock.patch(
+            "helm.run_helm_template",
+            return_value=deployment_yaml,
+        ),
+    ):
+        _generate_helm_manifests(config, output_dir, charts_dir, images=images)
+
+    deployment_file = output_dir / "default" / "deployment-my-app.yaml"
+    doc = yaml.safe_load(deployment_file.read_text())
+    init_containers = doc["spec"]["template"]["spec"]["initContainers"]
+    assert "volumeMounts" not in init_containers[0]
+
+
+def test_generate_helm_manifests_no_init(tmp_path: Path) -> None:
+    """Without init configured, Deployment should not have initContainers."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        init=None,  # no init script
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+
+    deployment_yaml = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+"""
+
+    with (
+        mock.patch(
+            "helm.pull_chart",
+            return_value=chart_dir,
+        ),
+        mock.patch(
+            "helm.run_helm_template",
+            return_value=deployment_yaml,
+        ),
+    ):
+        _generate_helm_manifests(config, output_dir, charts_dir)
+
+    deployment_file = output_dir / "default" / "deployment-my-app.yaml"
+    doc = yaml.safe_load(deployment_file.read_text())
+    assert "initContainers" not in doc["spec"]["template"]["spec"]
+
+
+def test_generate_helm_manifests_emits_configmap_without_mounts(
+    tmp_path: Path,
+) -> None:
+    """Helm config files should create a ConfigMap and annotate workloads."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    config_file = tmp_path / "app.conf"
+    config_file.write_text("[app]\ndebug = true\n")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        config={"app.conf": config_file},
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+    deployment_yaml = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    metadata:
+      annotations:
+        existing: annotation
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: my-stateful-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+"""
+
+    with mock.patch(
+        "helm.run_helm_template",
+        return_value=deployment_yaml,
+    ):
+        paths = _generate_helm_manifests(config, output_dir, charts_dir)
+
+    deployment_file = output_dir / "default" / "deployment-my-app.yaml"
+    statefulset_file = output_dir / "default" / "statefulset-my-stateful-app.yaml"
+    configmap_file = output_dir / "default" / "configmap-my-chart-config.yaml"
+
+    assert paths == {deployment_file, statefulset_file, configmap_file}
+
+    configmap = yaml.safe_load(configmap_file.read_text())
+    assert configmap["kind"] == "ConfigMap"
+    assert configmap["metadata"]["name"] == "my-chart-config"
+    assert configmap["metadata"]["namespace"] == "default"
+    assert configmap["data"] == {"app.conf": "[app]\ndebug = true\n"}
+
+    deployment = yaml.safe_load(deployment_file.read_text())
+    deployment_annotations = deployment["spec"]["template"]["metadata"]["annotations"]
+    assert deployment_annotations["existing"] == "annotation"
+    assert len(deployment_annotations["checksum/config"]) == 64
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert "volumes" not in pod_spec
+    assert "volumeMounts" not in pod_spec["containers"][0]
+
+    statefulset = yaml.safe_load(statefulset_file.read_text())
+    statefulset_annotations = statefulset["spec"]["template"]["metadata"]["annotations"]
+    assert (
+        statefulset_annotations["checksum/config"]
+        == deployment_annotations["checksum/config"]
+    )
+
+
+def test_generate_helm_manifests_injects_custom_token_audiences(
+    tmp_path: Path,
+) -> None:
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        custom_token_audiences=["vault", "api"],
+    )
+    deployment_yaml = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: myapp:1.0
+      - name: sidecar
+        image: sidecar:1.0
+"""
+
+    with mock.patch(
+        "helm.run_helm_template",
+        return_value=deployment_yaml,
+    ):
+        _generate_helm_manifests(config, tmp_path / "output", tmp_path / "charts")
+
+    deployment = yaml.safe_load(
+        (tmp_path / "output/default/deployment-my-app.yaml").read_text()
+    )
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert pod_spec["volumes"] == [
+        {
+            "name": "tokens",
+            "projected": {
+                "sources": [
+                    {
+                        "serviceAccountToken": {
+                            "path": "vault",
+                            "expirationSeconds": 3600,
+                            "audience": "vault",
+                        }
+                    },
+                    {
+                        "serviceAccountToken": {
+                            "path": "api",
+                            "expirationSeconds": 3600,
+                            "audience": "api",
+                        }
+                    },
+                ]
+            },
+        }
+    ]
+    expected_mount = {
+        "name": "tokens",
+        "mountPath": "/var/run/secrets/tokens",
+        "readOnly": True,
+    }
+    assert all(
+        container["volumeMounts"] == [expected_mount]
+        for container in pod_spec["containers"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("rendered_yaml", "deployment_count"),
+    [
+        (
+            """\
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+""",
+            0,
+        ),
+        (
+            """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: first
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: second
+""",
+            2,
+        ),
+    ],
+)
+def test_generate_helm_custom_token_audiences_requires_one_deployment(
+    tmp_path: Path, rendered_yaml: str, deployment_count: int
+) -> None:
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        custom_token_audiences=["vault"],
+    )
+
+    with (
+        mock.patch(
+            "helm.run_helm_template",
+            return_value=rendered_yaml,
+        ),
+        pytest.raises(
+            ValueError,
+            match=(
+                "Custom token audience injection for Helm chart 'my-chart' "
+                f"requires exactly one Deployment, found {deployment_count}"
+            ),
+        ),
+    ):
+        _generate_helm_manifests(config, tmp_path / "output", tmp_path / "charts")
+
+
+def test_name_overrides_avoid_helm_configmap_collisions(tmp_path: Path) -> None:
+    """Name overrides should distinguish ConfigMaps for a shared Helmfile release."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    first_config_file = tmp_path / "first.conf"
+    first_config_file.write_text("instance = first\n")
+    second_config_file = tmp_path / "second.conf"
+    second_config_file.write_text("instance = second\n")
+    configs = [
+        ChartConfig(
+            name="shared-release",
+            namespace="default",
+            chart=str(chart_dir),
+            repo=None,
+            version=None,
+            values=[],
+            release="shared-release",
+            config={"app.conf": first_config_file},
+            name_override="first-release",
+        ),
+        ChartConfig(
+            name="shared-release",
+            namespace="default",
+            chart=str(chart_dir),
+            repo=None,
+            version=None,
+            values=[],
+            release="shared-release",
+            config={"app.conf": second_config_file},
+            name_override="second-release",
+        ),
+    ]
+    output_dir = tmp_path / "output"
+
+    with mock.patch("helm.run_helm_template", return_value=""):
+        paths = generate_manifests(
+            [HelmBlock(configs)],
+            output_dir,
+            repo_root=tmp_path,
+            charts_dir=tmp_path / "charts",
+        )
+
+    first_path = output_dir / "default" / "configmap-first-release-config.yaml"
+    second_path = output_dir / "default" / "configmap-second-release-config.yaml"
+    assert first_path in paths
+    assert second_path in paths
+    assert yaml.safe_load(first_path.read_text())["data"] == {
+        "app.conf": "instance = first\n"
+    }
+    assert yaml.safe_load(second_path.read_text())["data"] == {
+        "app.conf": "instance = second\n"
+    }
+
+
+def test_generate_helm_manifests_config_checksum_changes_with_content(
+    tmp_path: Path,
+) -> None:
+    """Changing Helm config content should produce a different checksum."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    config_file = tmp_path / "app.conf"
+    config_file.write_text("debug = true\n")
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        release=None,
+        config={"app.conf": config_file},
+    )
+    deployment_yaml = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers: []
+"""
+
+    with mock.patch(
+        "helm.run_helm_template",
+        return_value=deployment_yaml,
+    ):
+        _generate_helm_manifests(config, tmp_path / "first", tmp_path / "charts")
+        config_file.write_text("debug = false\n")
+        _generate_helm_manifests(config, tmp_path / "second", tmp_path / "charts")
+
+    first = yaml.safe_load(
+        (tmp_path / "first/default/deployment-my-app.yaml").read_text()
+    )
+    second = yaml.safe_load(
+        (tmp_path / "second/default/deployment-my-app.yaml").read_text()
+    )
+    first_checksum = first["spec"]["template"]["metadata"]["annotations"][
+        "checksum/config"
+    ]
+    second_checksum = second["spec"]["template"]["metadata"]["annotations"][
+        "checksum/config"
+    ]
+    assert first_checksum != second_checksum
+
+
+def test_generate_helm_manifests_renders_values_files_with_variables(
+    tmp_path: Path,
+) -> None:
+    """Helm values files should be rendered with config variables before templating."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    values_file = tmp_path / "values.yaml"
+    values_file.write_text("hostname: {{domain}}\nreplicas: {{replicas}}\n")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[values_file],
+        variables={"domain": "example.com", "replicas": 2},
+        release=None,
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+    captured_values: dict[str, str] = {}
+
+    def fake_run_helm_template(
+        release_name: str,
+        chart: str,
+        namespace: str,
+        values_files: list[Path],
+        version: str | None = None,
+    ) -> str:
+        del release_name, chart, namespace, version
+        captured_values["content"] = values_files[0].read_text()
+        return ""
+
+    with mock.patch(
+        "helm.run_helm_template",
+        side_effect=fake_run_helm_template,
+    ):
+        paths = _generate_helm_manifests(config, output_dir, charts_dir)
+
+    assert paths == set()
+    assert captured_values["content"] == "hostname: example.com\nreplicas: 2\n"
+
+
+def test_generate_helm_manifests_raises_on_missing_variable_in_values_file(
+    tmp_path: Path,
+) -> None:
+    """Rendering values files should fail when a referenced variable is missing."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    values_file = tmp_path / "values.yaml"
+    values_file.write_text("hostname: {{domain}}\n")
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[values_file],
+        release=None,
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+
+    with pytest.raises(KeyNotFoundError):
+        _generate_helm_manifests(config, output_dir, charts_dir)
+
+
+def test_generate_helm_manifests_renders_extra_resources_with_variables(
+    tmp_path: Path,
+) -> None:
+    """Extra resource manifests should be rendered with config variables before parsing."""
+    chart_dir = tmp_path / "chart"
+    chart_dir.mkdir()
+    extra_dir = tmp_path / "extra"
+    extra_dir.mkdir()
+    (extra_dir / "configmap.yaml").write_text(
+        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: my-config\n"
+        "data:\n  domain: {{domain}}\n"
+    )
+
+    config = ChartConfig(
+        name="my-chart",
+        namespace="default",
+        chart=str(chart_dir),
+        repo=None,
+        version=None,
+        values=[],
+        variables={"domain": "example.com"},
+        release=None,
+        extra_resources=extra_dir,
+    )
+
+    output_dir = tmp_path / "output"
+    charts_dir = tmp_path / "charts"
+
+    with mock.patch(
+        "helm.run_helm_template",
+        return_value="",
+    ):
+        _generate_helm_manifests(config, output_dir, charts_dir)
+
+    written = list(output_dir.rglob("*.yaml"))
+    assert len(written) == 1
+    content = written[0].read_text()
+    assert "example.com" in content
+    assert "{{domain}}" not in content

--- a/plugins/tests/test_simple_block.py
+++ b/plugins/tests/test_simple_block.py
@@ -1,0 +1,1242 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the [[simple]] config block."""
+
+import textwrap
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from manifest_builder.blocks import ConfigBlock
+from manifest_builder.config import ManifestConfig, load_configs
+from manifest_builder.generator import generate_manifests
+from pystache.context import KeyNotFoundError
+
+from simple import SimpleBlock, SimpleConfig, generate_simple
+
+
+def write_toml(directory: Path, name: str, content: str) -> Path:
+    path = directory / name
+    path.write_text(textwrap.dedent(content))
+    return path
+
+
+def all_configs(blocks: Sequence[ConfigBlock]) -> tuple[ManifestConfig, ...]:
+    return tuple(config for block in blocks for config in block.iter_configs())
+
+
+def only_config(blocks: Sequence[ConfigBlock]) -> ManifestConfig:
+    (config,) = all_configs(blocks)
+    return config
+
+
+def config_blocks() -> list[ConfigBlock[Any]]:
+    """This directory's simple block, loaded the way a real run loads it."""
+    return [SimpleBlock()]
+
+
+def load_test_configs(config_dir: Path) -> Sequence[ConfigBlock]:
+    return load_configs(config_dir, config_blocks())
+
+
+def manifest_configs(
+    *,
+    simples: list[SimpleConfig] | None = None,
+) -> list[ConfigBlock[Any]]:
+    return [SimpleBlock(simples)]
+
+
+def _read_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def test_load_simple_config(tmp_path: Path) -> None:
+    """Simple config can omit name and use namespace as the generated name."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    (conf / "idcat").mkdir()
+    (conf / "idcat" / "myconfig.toml").write_text("[idcat]\nenabled = true\n")
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+
+        [[simple.config]]
+        "/config/myconfig.toml" = "idcat/myconfig.toml"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.name == "idcat"
+    assert config.namespace == "idcat"
+    assert config.image == "example.com/idcat:1.0"
+    assert config.config == {"/config/myconfig.toml": conf / "idcat" / "myconfig.toml"}
+
+
+def test_load_simple_config_uses_default_namespace(tmp_path: Path) -> None:
+    """Simple config can get its namespace from namespace-owner mode."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        image = "example.com/idcat:1.0"
+        """,
+    )
+
+    configs = load_configs(conf, config_blocks(), default_namespace="idcat")
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.name == "idcat"
+    assert config.namespace == "idcat"
+
+
+def test_load_simple_config_uses_default_image(tmp_path: Path) -> None:
+    """Simple config can get its image from namespace-mode API input."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        """,
+    )
+
+    configs = load_configs(
+        conf,
+        config_blocks(),
+        default_namespace="idcat",
+        default_image="example.com/idcat:1.0",
+    )
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.namespace == "idcat"
+    assert config.image == "example.com/idcat:1.0"
+
+
+def test_load_simple_config_rejects_image_with_default_image(tmp_path: Path) -> None:
+    """Config image and API image override are mutually exclusive."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        image = "example.com/idcat:1.0"
+        """,
+    )
+
+    with pytest.raises(ValueError, match="Cannot specify 'image'.*generate"):
+        load_configs(
+            conf,
+            config_blocks(),
+            default_namespace="idcat",
+            default_image="example.com/override:1.0",
+        )
+
+
+def test_load_simple_config_with_extra_resources(tmp_path: Path) -> None:
+    """Simple config can specify a directory with extra YAML resources."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    resources_dir = conf / "resources"
+    resources_dir.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        extra-resources = "resources"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.extra_resources == resources_dir
+
+
+def test_load_simple_config_with_iam_role_and_variables(tmp_path: Path) -> None:
+    """Simple iam-role is parsed with the variables used during rendering."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [variables]
+        account_id = "123456789012"
+        cluster_name = "berries"
+
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        iam-role = "arn:aws:iam::{{account_id}}:role/{{cluster_name}}-idcat"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.iam_role == "arn:aws:iam::{{account_id}}:role/{{cluster_name}}-idcat"
+    assert config.variables == {
+        "account_id": "123456789012",
+        "cluster_name": "berries",
+    }
+
+
+def test_load_simple_config_with_k8s_role(tmp_path: Path) -> None:
+    """Simple config can specify a Kubernetes Role to bind to its ServiceAccount."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        k8s-role = "idcat-reader"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.k8s_role == "idcat-reader"
+
+
+def test_load_simple_config_with_service_account_annotations(tmp_path: Path) -> None:
+    """Simple config can specify a table of ServiceAccount annotations."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+
+        [simple.service-account-annotations]
+        "example.com/owner" = "platform"
+        "example.com/team" = "berries"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.service_account_annotations == {
+        "example.com/owner": "platform",
+        "example.com/team": "berries",
+    }
+
+
+def test_load_simple_config_service_account_annotations_must_be_strings(
+    tmp_path: Path,
+) -> None:
+    """Non-string annotation values are rejected."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+
+        [simple.service-account-annotations]
+        "example.com/replicas" = 3
+        """,
+    )
+
+    with pytest.raises(
+        ValueError, match=r"'service-account-annotations' must be a table"
+    ):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_rejects_role_arn_annotation_with_iam_role(
+    tmp_path: Path,
+) -> None:
+    """Setting the role-arn annotation and iam-role together fails clearly."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        iam-role = "arn:aws:iam::123456789012:role/berries-idcat"
+
+        [simple.service-account-annotations]
+        "eks.amazonaws.com/role-arn" = "arn:aws:iam::123456789012:role/other"
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"cannot set 'eks\.amazonaws\.com/role-arn' when 'iam-role'",
+    ):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_with_arch(tmp_path: Path) -> None:
+    """Simple config can declare a node architecture for the Pod nodeSelector."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        arch = "arm64"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.arch == "arm64"
+
+
+def test_load_simple_config_with_args(tmp_path: Path) -> None:
+    """Simple config accepts an ordered list of container arguments."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        args = ["serve", "--port=8080"]
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.args == ["serve", "--port=8080"]
+
+
+def test_load_simple_config_args_must_be_list_of_strings(tmp_path: Path) -> None:
+    """Simple args reject scalar values instead of changing their meaning."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        args = "serve"
+        """,
+    )
+
+    with pytest.raises(ValueError, match="'args' must be a list of strings"):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_with_custom_token_audiences(tmp_path: Path) -> None:
+    """Simple config can specify custom audiences for projected tokens."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        custom-token-audiences = ["vault", "api"]
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.custom_token_audiences == ["vault", "api"]
+
+
+def test_load_simple_config_custom_token_audiences_must_be_list(
+    tmp_path: Path,
+) -> None:
+    """Simple custom token audiences must be configured as a string list."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        custom-token-audiences = "vault"
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="'custom-token-audiences' must be a list of strings",
+    ):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_arch_must_be_string(tmp_path: Path) -> None:
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        arch = 64
+        """,
+    )
+
+    with pytest.raises(ValueError, match="'arch' must be a string"):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_with_external_secrets(tmp_path: Path) -> None:
+    """An external-secrets list is preserved in order."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        external-secrets = ["/email-password", "/db/credentials"]
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.external_secrets == ["/email-password", "/db/credentials"]
+
+
+def test_load_simple_config_with_external_secrets_string(tmp_path: Path) -> None:
+    """A single external secret is normalized into a one-element list."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        external-secrets = "/api-key"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.external_secrets == ["/api-key"]
+
+
+def test_load_simple_config_with_external_secret(tmp_path: Path) -> None:
+    """A singular external-secret is normalized to a one-element list."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        external-secret = "/api-key"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.external_secrets == ["/api-key"]
+
+
+def test_load_simple_config_rejects_both_external_secret_forms(
+    tmp_path: Path,
+) -> None:
+    """The singular and plural external secret fields are mutually exclusive."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        external-secret = "/api-key"
+        external-secrets = ["/email-password"]
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot specify both 'external-secret' and 'external-secrets'",
+    ):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_external_secret_must_be_string(tmp_path: Path) -> None:
+    """The singular external-secret field only accepts a string."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        external-secret = ["/api-key"]
+        """,
+    )
+
+    with pytest.raises(ValueError, match="'external-secret' must be a string"):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_external_secrets_must_be_strings(tmp_path: Path) -> None:
+    """external-secrets must be a string or list of strings."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        external-secrets = [1]
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="'external-secrets' must be a string or list of strings",
+    ):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_with_random_secret(tmp_path: Path) -> None:
+    """A single random-secret is normalized into a one-element list."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        random-secret = "SESSION_KEY"
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.random_secrets == ["SESSION_KEY"]
+
+
+def test_load_simple_config_with_random_secrets_list(tmp_path: Path) -> None:
+    """A random-secrets list is preserved in order."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        random-secrets = ["API_KEY", "SIGNING_KEY"]
+        """,
+    )
+
+    configs = load_test_configs(conf)
+    config = only_config(configs)
+    assert isinstance(config, SimpleConfig)
+    assert config.random_secrets == ["API_KEY", "SIGNING_KEY"]
+
+
+def test_load_simple_config_rejects_both_random_secret_forms(tmp_path: Path) -> None:
+    """Specifying both random-secret and random-secrets is an error."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        random-secret = "SESSION_KEY"
+        random-secrets = ["API_KEY"]
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot specify both 'random-secret' and 'random-secrets'",
+    ):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_random_secrets_must_be_list_of_strings(
+    tmp_path: Path,
+) -> None:
+    """random-secrets must be a list of strings."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        random-secrets = "API_KEY"
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="'random-secrets' must be a list of strings",
+    ):
+        load_test_configs(conf)
+
+
+def test_load_simple_config_unknown_field_raises(tmp_path: Path) -> None:
+    """Unknown simple fields should fail before generation."""
+    conf = tmp_path / "conf"
+    conf.mkdir()
+    write_toml(
+        conf,
+        "config.toml",
+        """\
+        [[simple]]
+        namespace = "idcat"
+        image = "example.com/idcat:1.0"
+        iam_role = "typo"
+        """,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Unknown field in \[\[simple\]\]: 'iam_role' on line 4",
+    ):
+        load_test_configs(conf)
+
+
+def test_validate_config_simple_extra_resources_missing_directory(
+    tmp_path: Path,
+) -> None:
+    """Validation should fail if simple extra_resources directory doesn't exist."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="example.com/idcat:1.0",
+        extra_resources=tmp_path / "nonexistent",
+    )
+    with pytest.raises(ValueError, match="Extra resources directory not found"):
+        SimpleBlock().validate(config, tmp_path)
+
+
+def test_validate_config_simple_extra_resources_not_a_directory(tmp_path: Path) -> None:
+    """Validation should fail if simple extra_resources path is not a directory."""
+    not_a_dir = tmp_path / "file.txt"
+    not_a_dir.write_text("content")
+
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="example.com/idcat:1.0",
+        extra_resources=not_a_dir,
+    )
+    with pytest.raises(ValueError, match="Extra resources path is not a directory"):
+        SimpleBlock().validate(config, tmp_path)
+
+
+def _read_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def test_generate_simple_writes_deployment_from_bundled_template(
+    tmp_path: Path,
+) -> None:
+    """Simple generation creates a Deployment and ClusterIP Service."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+    )
+
+    paths = generate_simple(config, tmp_path / "output")
+
+    assert {path.name for path in paths} == {
+        "deployment-idcat.yaml",
+        "service-idcat.yaml",
+    }
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    assert deployment["kind"] == "Deployment"
+    assert deployment["metadata"]["name"] == "idcat"
+    assert deployment["metadata"]["namespace"] == "idcat"
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == "registry.example.com/idcat:1.0"
+    assert container["ports"] == [{"name": "http", "containerPort": 8080}]
+    assert "args" not in container
+
+    service = _read_yaml(tmp_path / "output" / "idcat" / "service-idcat.yaml")
+    assert service["kind"] == "Service"
+    assert service["metadata"]["name"] == "idcat"
+    assert service["metadata"]["namespace"] == "idcat"
+    assert service["spec"]["type"] == "ClusterIP"
+    assert service["spec"]["selector"] == {"app": "idcat"}
+    assert service["spec"]["ports"] == [
+        {"name": "http", "port": 80, "targetPort": "http"}
+    ]
+
+
+def test_generate_simple_propagates_args_to_deployment(tmp_path: Path) -> None:
+    """Configured args are preserved as strings in the container spec."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        args=["serve", "--port=8080", "true", "key: value"],
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    assert container["args"] == ["serve", "--port=8080", "true", "key: value"]
+
+
+def test_generate_simple_writes_configmap_when_config_is_specified(
+    tmp_path: Path,
+) -> None:
+    """Config entries create ConfigMaps and mount them in the Deployment."""
+    config_file = tmp_path / "myconfig.toml"
+    config_file.write_text("[idcat]\nenabled = true\n")
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        config={"/config/myconfig.toml": config_file},
+    )
+
+    paths = generate_simple(config, tmp_path / "output")
+
+    assert {path.name for path in paths} == {
+        "deployment-idcat.yaml",
+        "service-idcat.yaml",
+        "configmap-idcat-config.yaml",
+    }
+    assert not any(
+        path.name.startswith(("certificate-", "gateway-", "httproute-"))
+        for path in paths
+    )
+
+    configmap = _read_yaml(
+        tmp_path / "output" / "idcat" / "configmap-idcat-config.yaml"
+    )
+    assert configmap["kind"] == "ConfigMap"
+    assert configmap["metadata"]["name"] == "idcat-config"
+    assert configmap["metadata"]["namespace"] == "idcat"
+    assert configmap["data"]["myconfig.toml"] == "[idcat]\nenabled = true\n"
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    pod_template = deployment["spec"]["template"]
+    assert "checksum/config" in pod_template["metadata"]["annotations"]
+    pod_spec = pod_template["spec"]
+    assert pod_spec["volumes"] == [
+        {"name": "idcat-config", "configMap": {"name": "idcat-config"}}
+    ]
+    assert pod_spec["containers"][0]["volumeMounts"] == [
+        {"name": "idcat-config", "mountPath": "/config"}
+    ]
+
+
+def test_generate_simple_renders_config_file_with_variables(
+    tmp_path: Path,
+) -> None:
+    """Config files are rendered with the simple template context."""
+    config_file = tmp_path / "myconfig.toml"
+    config_file.write_text('[idcat]\ndomain = "{{domain}}"\nreplicas = {{replicas}}\n')
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        config={"/config/myconfig.toml": config_file},
+        variables={"domain": "example.com"},
+        replicas=3,
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    configmap = _read_yaml(
+        tmp_path / "output" / "idcat" / "configmap-idcat-config.yaml"
+    )
+    assert configmap["data"]["myconfig.toml"] == (
+        '[idcat]\ndomain = "example.com"\nreplicas = 3\n'
+    )
+
+
+def test_generate_simple_config_file_missing_variable_raises(
+    tmp_path: Path,
+) -> None:
+    """Missing variables in rendered config files fail instead of being blank."""
+    config_file = tmp_path / "myconfig.toml"
+    config_file.write_text('[idcat]\ndomain = "{{domain}}"\n')
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        config={"/config/myconfig.toml": config_file},
+    )
+
+    with pytest.raises(KeyNotFoundError):
+        generate_simple(config, tmp_path / "output")
+
+
+def test_generate_simple_writes_serviceaccount_when_iam_role_is_specified(
+    tmp_path: Path,
+) -> None:
+    """iam_role creates a ServiceAccount and references it from the Deployment."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        iam_role=("arn:aws:iam::{{account_id}}:role/{{cluster_name}}-idcat"),
+        variables={"account_id": "123456789012", "cluster_name": "berries"},
+    )
+
+    paths = generate_simple(config, tmp_path / "output")
+
+    assert {path.name for path in paths} == {
+        "deployment-idcat.yaml",
+        "service-idcat.yaml",
+        "serviceaccount-idcat.yaml",
+    }
+
+    serviceaccount = _read_yaml(
+        tmp_path / "output" / "idcat" / "serviceaccount-idcat.yaml"
+    )
+    assert serviceaccount["kind"] == "ServiceAccount"
+    assert serviceaccount["metadata"]["name"] == "idcat"
+    assert serviceaccount["metadata"]["namespace"] == "idcat"
+    assert serviceaccount["metadata"]["annotations"] == {
+        "eks.amazonaws.com/role-arn": ("arn:aws:iam::123456789012:role/berries-idcat")
+    }
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    assert deployment["spec"]["template"]["spec"]["serviceAccountName"] == "idcat"
+
+
+def test_generate_simple_writes_serviceaccount_annotations(
+    tmp_path: Path,
+) -> None:
+    """service_account_annotations create a ServiceAccount with those annotations."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        service_account_annotations={
+            "example.com/owner": "platform",
+            "example.com/team": "{{team}}",
+        },
+        variables={"team": "berries"},
+    )
+
+    paths = generate_simple(config, tmp_path / "output")
+
+    assert {path.name for path in paths} == {
+        "deployment-idcat.yaml",
+        "service-idcat.yaml",
+        "serviceaccount-idcat.yaml",
+    }
+
+    serviceaccount = _read_yaml(
+        tmp_path / "output" / "idcat" / "serviceaccount-idcat.yaml"
+    )
+    assert serviceaccount["kind"] == "ServiceAccount"
+    assert serviceaccount["metadata"]["name"] == "idcat"
+    assert serviceaccount["metadata"]["namespace"] == "idcat"
+    assert serviceaccount["metadata"]["annotations"] == {
+        "example.com/owner": "platform",
+        "example.com/team": "berries",
+    }
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    assert deployment["spec"]["template"]["spec"]["serviceAccountName"] == "idcat"
+
+
+def test_generate_simple_combines_iam_role_and_serviceaccount_annotations(
+    tmp_path: Path,
+) -> None:
+    """iam_role and service_account_annotations merge into one annotations block."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        iam_role="arn:aws:iam::123456789012:role/berries-idcat",
+        service_account_annotations={"example.com/owner": "platform"},
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    serviceaccount = _read_yaml(
+        tmp_path / "output" / "idcat" / "serviceaccount-idcat.yaml"
+    )
+    assert serviceaccount["metadata"]["annotations"] == {
+        "eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/berries-idcat",
+        "example.com/owner": "platform",
+    }
+
+
+def test_generate_simple_serviceaccount_annotation_values_are_quoted(
+    tmp_path: Path,
+) -> None:
+    """Annotation values that look like non-strings stay strings in the output."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        service_account_annotations={"example.com/enabled": "true"},
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    serviceaccount = _read_yaml(
+        tmp_path / "output" / "idcat" / "serviceaccount-idcat.yaml"
+    )
+    assert serviceaccount["metadata"]["annotations"] == {"example.com/enabled": "true"}
+    assert isinstance(
+        serviceaccount["metadata"]["annotations"]["example.com/enabled"], str
+    )
+
+
+def test_generate_simple_writes_rolebinding_when_k8s_role_is_specified(
+    tmp_path: Path,
+) -> None:
+    """k8s_role creates a ServiceAccount and binds it to the named Role."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        k8s_role="{{role_name}}",
+        variables={"role_name": "idcat-reader"},
+    )
+
+    paths = generate_simple(config, tmp_path / "output")
+
+    assert {path.name for path in paths} == {
+        "deployment-idcat.yaml",
+        "service-idcat.yaml",
+        "serviceaccount-idcat.yaml",
+        "rolebinding-idcat-idcat-reader.yaml",
+    }
+
+    serviceaccount = _read_yaml(
+        tmp_path / "output" / "idcat" / "serviceaccount-idcat.yaml"
+    )
+    assert serviceaccount["kind"] == "ServiceAccount"
+    assert serviceaccount["metadata"]["name"] == "idcat"
+    assert serviceaccount["metadata"]["namespace"] == "idcat"
+    assert "annotations" not in serviceaccount["metadata"]
+
+    rolebinding = _read_yaml(
+        tmp_path / "output" / "idcat" / "rolebinding-idcat-idcat-reader.yaml"
+    )
+    assert rolebinding["kind"] == "RoleBinding"
+    assert rolebinding["metadata"]["name"] == "idcat-idcat-reader"
+    assert rolebinding["metadata"]["namespace"] == "idcat"
+    assert rolebinding["subjects"] == [
+        {"kind": "ServiceAccount", "name": "idcat", "namespace": "idcat"}
+    ]
+    assert rolebinding["roleRef"] == {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "Role",
+        "name": "idcat-reader",
+    }
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    assert deployment["spec"]["template"]["spec"]["serviceAccountName"] == "idcat"
+
+
+def test_generate_simple_renders_extra_resources_with_variables(
+    tmp_path: Path,
+) -> None:
+    """Extra resource manifests are rendered and namespace defaults are applied."""
+    extra_dir = tmp_path / "extra"
+    extra_dir.mkdir()
+    (extra_dir / "configmap.yaml").write_text(
+        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{k8s_name}}-settings\n"
+        "data:\n  domain: {{domain}}\n"
+    )
+    (extra_dir / "storageclass.yaml").write_text(
+        "apiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n"
+        "  name: {{k8s_name}}-storage\nprovisioner: example.com/storage\n"
+    )
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        variables={"domain": "example.com"},
+        extra_resources=extra_dir,
+    )
+
+    paths = generate_simple(config, tmp_path / "output")
+
+    assert "configmap-idcat-settings.yaml" in {path.name for path in paths}
+    configmap = _read_yaml(
+        tmp_path / "output" / "idcat" / "configmap-idcat-settings.yaml"
+    )
+    assert configmap["metadata"]["namespace"] == "idcat"
+    assert configmap["data"]["domain"] == "example.com"
+
+    storageclass = _read_yaml(
+        tmp_path / "output" / "cluster" / "storageclass-idcat-storage.yaml"
+    )
+    assert storageclass["kind"] == "StorageClass"
+    assert "namespace" not in storageclass["metadata"]
+
+
+def test_generate_simple_sets_arch_node_selector(tmp_path: Path) -> None:
+    """arch field renders kubernetes.io/arch nodeSelector in the Pod spec."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        arch="arm64",
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert pod_spec["nodeSelector"] == {"kubernetes.io/arch": "arm64"}
+
+
+def test_generate_simple_omits_arch_node_selector_when_unset(tmp_path: Path) -> None:
+    """Without arch, no nodeSelector is added to the Pod spec."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    assert "nodeSelector" not in deployment["spec"]["template"]["spec"]
+
+
+def test_generate_simple_custom_token_audiences_inject_projected_tokens(
+    tmp_path: Path,
+) -> None:
+    """Custom token audiences inject projected service account tokens."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        custom_token_audiences=["vault", "api"],
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    container = pod_spec["containers"][0]
+    assert container["volumeMounts"] == [
+        {
+            "name": "tokens",
+            "mountPath": "/var/run/secrets/tokens",
+            "readOnly": True,
+        }
+    ]
+    assert pod_spec["volumes"] == [
+        {
+            "name": "tokens",
+            "projected": {
+                "sources": [
+                    {
+                        "serviceAccountToken": {
+                            "path": "vault",
+                            "expirationSeconds": 3600,
+                            "audience": "vault",
+                        }
+                    },
+                    {
+                        "serviceAccountToken": {
+                            "path": "api",
+                            "expirationSeconds": 3600,
+                            "audience": "api",
+                        }
+                    },
+                ]
+            },
+        }
+    ]
+
+
+def test_generate_simple_external_secrets_injects_volumes_and_mounts(
+    tmp_path: Path,
+) -> None:
+    """External secrets are mounted as Secret volumes named after the mount path."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        external_secrets=["/email-password", "/db/credentials"],
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert pod_spec["containers"][0]["volumeMounts"] == [
+        {"name": "email-password", "mountPath": "/email-password"},
+        {"name": "db-credentials", "mountPath": "/db/credentials"},
+    ]
+    assert pod_spec["volumes"] == [
+        {"name": "email-password", "secret": {"secretName": "email-password"}},
+        {"name": "db-credentials", "secret": {"secretName": "db-credentials"}},
+    ]
+
+
+def test_generate_simple_omits_external_secrets_when_unset(tmp_path: Path) -> None:
+    """Without external secrets, no Secret volumes are produced."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    assert "volumes" not in deployment["spec"]["template"]["spec"]
+
+
+def test_generate_simple_random_secret_emits_manifest_and_mount(
+    tmp_path: Path,
+) -> None:
+    """A single random-secret emits a RandomSecret and mounts it at /random-secrets."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        random_secrets=["SESSION_KEY"],
+    )
+
+    paths = generate_simple(config, tmp_path / "output")
+
+    assert "randomsecret-idcat.yaml" in {path.name for path in paths}
+    random_secret = _read_yaml(
+        tmp_path / "output" / "idcat" / "randomsecret-idcat.yaml"
+    )
+    assert random_secret["apiVersion"] == "noa.re/v1alpha1"
+    assert random_secret["kind"] == "RandomSecret"
+    assert random_secret["metadata"]["name"] == "idcat"
+    assert random_secret["metadata"]["namespace"] == "idcat"
+    assert random_secret["spec"]["secrets"] == [{"name": "SESSION_KEY"}]
+
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert pod_spec["containers"][0]["volumeMounts"] == [
+        {"name": "random-secrets", "mountPath": "/random-secrets"}
+    ]
+    assert pod_spec["volumes"] == [
+        {"name": "random-secrets", "secret": {"secretName": "idcat"}}
+    ]
+
+
+def test_generate_simple_random_secrets_list_enumerates_names(tmp_path: Path) -> None:
+    """A random-secrets list enumerates each name into the RandomSecret spec."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+        random_secrets=["API_KEY", "SIGNING_KEY"],
+    )
+
+    generate_simple(config, tmp_path / "output")
+
+    random_secret = _read_yaml(
+        tmp_path / "output" / "idcat" / "randomsecret-idcat.yaml"
+    )
+    assert random_secret["spec"]["secrets"] == [
+        {"name": "API_KEY"},
+        {"name": "SIGNING_KEY"},
+    ]
+
+
+def test_generate_simple_omits_random_secret_when_unset(tmp_path: Path) -> None:
+    """Without random secrets, no RandomSecret or mount is produced."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+    )
+
+    paths = generate_simple(config, tmp_path / "output")
+
+    assert not any(path.name.startswith("randomsecret-") for path in paths)
+    deployment = _read_yaml(tmp_path / "output" / "idcat" / "deployment-idcat.yaml")
+    assert "volumes" not in deployment["spec"]["template"]["spec"]
+
+
+def test_generate_manifests_with_simple_config(tmp_path: Path) -> None:
+    """generate_manifests dispatches to simple generation."""
+    config = SimpleConfig(
+        name="idcat",
+        namespace="idcat",
+        image="registry.example.com/idcat:1.0",
+    )
+
+    paths = generate_manifests(
+        [SimpleBlock([config])],
+        tmp_path / "output",
+        repo_root=tmp_path,
+    )
+
+    assert {path.name for path in paths} == {
+        "deployment-idcat.yaml",
+        "service-idcat.yaml",
+        "namespace-idcat.yaml",
+    }

--- a/plugins/tests/test_website.py
+++ b/plugins/tests/test_website.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 from manifest_builder.generator import ManifestError, generate_manifests
 
-from website import WebsiteConfig, WebsiteConfigHandler, generate_website
+from website import WebsiteBlock, WebsiteConfig, generate_website
 
 SIMPLE_DEPLOYMENT = """\
 apiVersion: apps/v1
@@ -154,7 +154,7 @@ def test_generate_manifests_with_website_config(tmp_path: Path) -> None:
     output_dir = tmp_path / "output"
 
     generate_manifests(
-        [WebsiteConfigHandler([config])],
+        [WebsiteBlock([config])],
         output_dir,
         repo_root=tmp_path,
     )
@@ -209,7 +209,7 @@ def test_generate_manifests_removes_stale_website_files(tmp_path: Path) -> None:
 
     config = WebsiteConfig(name="zq.lu", namespace="web")
     generate_manifests(
-        [WebsiteConfigHandler([config])],
+        [WebsiteBlock([config])],
         output_dir,
         repo_root=tmp_path,
     )
@@ -268,7 +268,7 @@ def test_generate_manifests_detects_output_file_conflicts(tmp_path: Path) -> Non
         pytest.raises(ManifestError, match="Configuration conflict") as exc_info,
     ):
         generate_manifests(
-            [WebsiteConfigHandler([config1, config2])],
+            [WebsiteBlock([config1, config2])],
             output_dir,
             repo_root=tmp_path,
         )

--- a/plugins/tests/test_website_config.py
+++ b/plugins/tests/test_website_config.py
@@ -7,15 +7,15 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
+from manifest_builder.blocks import ConfigBlock
 from manifest_builder.config import (
     DEFAULT_REPLICA_COUNT,
     ManifestConfig,
     load_configs,
     resolve_configs,
 )
-from manifest_builder.handlers import ConfigHandler
 
-from website import WebsiteConfig, WebsiteConfigHandler
+from website import WebsiteBlock, WebsiteConfig
 
 
 def write_toml(directory: Path, name: str, content: str) -> Path:
@@ -25,33 +25,33 @@ def write_toml(directory: Path, name: str, content: str) -> Path:
 
 
 def all_configs(
-    handlers: Sequence[ConfigHandler],
+    blocks: Sequence[ConfigBlock],
 ) -> tuple[ManifestConfig, ...]:
-    return tuple(config for handler in handlers for config in handler.iter_configs())
+    return tuple(config for block in blocks for config in block.iter_configs())
 
 
 def only_config(
-    handlers: Sequence[ConfigHandler],
+    blocks: Sequence[ConfigBlock],
 ) -> ManifestConfig:
-    (config,) = all_configs(handlers)
+    (config,) = all_configs(blocks)
     return config
 
 
-def config_handlers() -> list[WebsiteConfigHandler]:
-    return [WebsiteConfigHandler()]
+def config_blocks() -> list[WebsiteBlock]:
+    return [WebsiteBlock()]
 
 
 def load_test_configs(
     config_dir: Path,
-) -> Sequence[ConfigHandler]:
-    return load_configs(config_dir, config_handlers())
+) -> Sequence[ConfigBlock]:
+    return load_configs(config_dir, config_blocks())
 
 
 def manifest_configs(
     *,
     websites: list[WebsiteConfig] | None = None,
-) -> list[WebsiteConfigHandler]:
-    return [WebsiteConfigHandler(websites)]
+) -> list[WebsiteBlock]:
+    return [WebsiteBlock(websites)]
 
 
 # WebsiteConfig parsing
@@ -173,7 +173,7 @@ def test_load_website_config_uses_default_image(tmp_path: Path) -> None:
 
     configs = load_configs(
         conf_dir,
-        config_handlers(),
+        config_blocks(),
         default_namespace="production",
         default_image="nginx:latest",
     )
@@ -202,7 +202,7 @@ def test_load_website_config_rejects_image_with_default_image(
     with pytest.raises(ValueError, match="Cannot specify 'image'.*generate"):
         load_configs(
             conf_dir,
-            config_handlers(),
+            config_blocks(),
             default_namespace="production",
             default_image="example.com/override:1.0",
         )
@@ -453,7 +453,7 @@ def test_validate_config_missing_config_file(tmp_path: Path) -> None:
         config={"/config/app.toml": tmp_path / "nonexistent.toml"},
     )
     with pytest.raises(ValueError, match="Config file not found"):
-        WebsiteConfigHandler().validate(config, tmp_path)
+        WebsiteBlock().validate(config, tmp_path)
 
 
 def test_load_website_config_with_extra_hostnames_string(tmp_path: Path) -> None:

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "manifest-builder"
-version = "0.7.0"
+version = "0.7.0.post2+gd12cc8804"
 source = { registry = "https://repo.noa.re/" }
 dependencies = [
     { name = "click" },
@@ -108,7 +108,7 @@ dependencies = [
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://repo.noa.re/manifest-builder/manifest_builder-0.7.0-py3-none-any.whl", hash = "sha256:7a6b041f9592972c3d9dfb98440b1f1f28f79bf6390dc9946b3eac624204923f", size = 55546 },
+    { url = "https://repo.noa.re/manifest-builder/manifest_builder-0.7.0.post2%2Bgd12cc8804-py3-none-any.whl", hash = "sha256:5c461c13ac0042199a8c2ce8d4757b431fb9d8affafb84363aa73235d94386b2", size = 44237 },
 ]
 
 [[package]]

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -99,7 +99,7 @@ wheels = [
 
 [[package]]
 name = "manifest-builder"
-version = "0.6.0.post1+g412fc32fd"
+version = "0.7.0"
 source = { registry = "https://repo.noa.re/" }
 dependencies = [
     { name = "click" },
@@ -108,7 +108,7 @@ dependencies = [
     { name = "pyyaml" },
 ]
 wheels = [
-    { url = "https://repo.noa.re/manifest-builder/manifest_builder-0.6.0.post1%2Bg412fc32fd-py3-none-any.whl", hash = "sha256:7558d1a96a1449d8e2df94245b2a78c6d2886e67bcb9c02b1358e292c47cfa62", size = 66402 },
+    { url = "https://repo.noa.re/manifest-builder/manifest_builder-0.7.0-py3-none-any.whl", hash = "sha256:7a6b041f9592972c3d9dfb98440b1f1f28f79bf6390dc9946b3eac624204923f", size = 55546 },
 ]
 
 [[package]]

--- a/plugins/website.py
+++ b/plugins/website.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from manifest_builder.blocks import ConfigBlock, GenerationContext
 from manifest_builder.config import (
     DEFAULT_REPLICA_COUNT,
     validate_known_fields,
 )
-from manifest_builder.handlers import ConfigHandler, GenerationContext
 from manifest_builder.k8s import (
     CLUSTER_SCOPED_KINDS,
     config_checksum,
@@ -58,7 +58,7 @@ def validate_website_config(config: WebsiteConfig) -> None:
             )
 
 
-class WebsiteConfigHandler(ConfigHandler[WebsiteConfig]):
+class WebsiteBlock(ConfigBlock[WebsiteConfig]):
     """Generate manifests for website configs."""
 
     def __init__(self, configs: Sequence[WebsiteConfig] | None = None) -> None:


### PR DESCRIPTION
Three commits.

**1. `WebsiteConfigHandler` → `WebsiteBlock`** — follows the manifest-builder rename in nresare/manifest-builder#130, where the team's "block" wording replaced "config handler".

**2. Local copies of the helm and simple blocks** — manifest-builder ships only `copy` now; every other block belongs to the configuration directory that uses it (nresare/manifest-builder#131). `helm.py` and `simple.py` arrive here with their tests, and simple's templates come along under `plugins/templates/simple`, resolved relative to the plugin module the way `website.py` already does. These are free to diverge from the copies in other configuration repositories now, which is the point.

**3. `plugins/uv.lock` → `0.7.0.post2+gd12cc8804`** — the local blocks cannot load while manifest-builder still ships its own, so the lock moves with them:

```
Configuration error: Config blocks HelmBlock and HelmBlock both claim the top-level key 'helm'
```

That version is the post build of the commit tagged `v0.7.1`; the `0.7.1` artifact is not on the index, so the lock names what is installable. Same commit either way.

## Verification

All against the published build named in the lock, not a local wheel:

- 187 tests pass in `plugins/`; `ruff check`, `ruff format --check`, `ty check` clean.
- Generating this configuration is byte-identical before and after: 481 manifests, baseline built from manifest-builder at `192ba33`, the commit before any of this work.